### PR TITLE
upload zip with root directory

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -184,7 +184,7 @@ function deploy(command: cli.IDeployCommand): Promise<void> {
                                     reject(error);
                                     return;
                                 }
-                                
+
                                 var baseDirectoryPath = path.dirname(directoryPath);
                                 var fileName: string = generateRandomFilename(15) + ".zip";
                                 var zipFile = new yazl.ZipFile();


### PR DESCRIPTION
This change makes it such that if a directory is specified for upload, eg "c:/myapp/www", the generated zip folder will also contain a "www" folder in the root. This prevents a gotcha when working with the Cordova SDK which expects the www folder to be present. 

@itsananderson @shishirx34 @dlebu 
