### PR TITLE
Remove adding empty directories to zip from CLI

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -206,16 +206,6 @@ function deploy(command: cli.IDeployCommand): Promise<void> {
                                         resolve({ isTemporary: true, path: filePath });
                                     });
 
-                                for (var i = 0; i < directories.length; ++i) {
-                                    var directory: string = directories[i];
-                                    var relativePath: string = path.relative(baseDirectoryPath, directory);
-
-                                    // yazl does not like backslash (\) in the metadata path.
-                                    relativePath = slash(relativePath);
-                                    
-                                    zipFile.addEmptyDirectory(relativePath);
-                                }
-
                                 for (var i = 0; i < files.length; ++i) {
                                     var file: string = files[i];
                                     var relativePath: string = path.relative(baseDirectoryPath, file);


### PR DESCRIPTION
Adding empty directories to zip would change the hash for the same uploads over and over again. It is not worth the effort to add support for adding empty folders.
