### PR TITLE
Bumping version and updating NPM package description

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-push-cli",
-  "version": "1.0.0-beta",
-  "description": "Source code for the CodePush command line interface",
+  "version": "1.0.2-beta",
+  "description": "Management CLI for the CodePush service",
   "main": "script/cli.js",
   "scripts": {
     "test": "gulp test"


### PR DESCRIPTION
I published the CLI as 1.0.1-beta only to realize that our package description wasn't super great, so I'm having to bump the version again :( That is why I jumped it from 1.0.0 to 1.0.2
