### PR TITLE
Updating access-key rm command's help output

### DIFF
--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -44,7 +44,7 @@ function accessKeyRemove(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
     yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <accessKey>")
         .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
-        .example("access-key " + commandName + " 8d6513de-050c-4788-96f7-b2a50dd9684v", "Removes the \"8d6513de-050c-4788-96f7-b2a50dd9684c\" access key");
+        .example("access-key " + commandName + " 8d6513de-050c-4788-96f7-b2a50dd9684v", "Removes the \"8d6513de-050c-4788-96f7-b2a50dd9684v\" access key");
 
     addCommonConfiguration(yargs);
 }


### PR DESCRIPTION
This changes does two things:
1. Update the name of the accessKeyName parameter to simply accessKey, to better reflect the fact that the parameter expects the key value, not some kind of name for the key
2. Updates the example to better reflect an actual scenario, since the use of "abc" as the key kind of implies that you're passing in some kind of label for the key
