### PR TITLE
Cleaning up package.json

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -13,7 +13,15 @@
     "type": "git",
     "url": "https://github.com/Microsoft/code-push/"
   },
-  "author": "Microsoft",
+  "keywords": [
+    "code",
+    "push",
+    "cordova",
+    "react-native",
+    "react"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
   "dependencies": {
     "code-push": "1.0.0-beta",
     "base-64": "^0.1.0",


### PR DESCRIPTION
We were missing the license and keyword fields in our package.json, and the author field wasn't consistent with the other repos (e.g. Cordova and React Native plugins)