### PR TITLE
Add promote deployment functionality

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -11,6 +11,7 @@
     deploymentRename,
     login,
     logout,
+    promote,
     register,
     release
 }
@@ -68,6 +69,12 @@ export interface IDeploymentRenameCommand extends ICommand {
 
 export interface ILoginCommand extends ICommand {
     serverUrl: string;
+}
+
+export interface IPromoteCommand extends ICommand {
+    appName: string;
+    sourceDeploymentName: string;
+    destDeploymentName: string;
 }
 
 export interface IRegisterCommand extends ICommand {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -592,9 +592,9 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
     var destDeploymentId: string;
     
     return getAppId(command.appName)
-        .then((gotAppId: string): Promise<string> => {
-            throwForInvalidAppId(gotAppId, command.appName);
-            appId = gotAppId;
+        .then((appIdResult: string): Promise<string> => {
+            throwForInvalidAppId(appIdResult, command.appName);
+            appId = appIdResult;
             return getDeploymentId(appId, command.sourceDeploymentName);
         })
         .then((deploymentId: string): Promise<string> => {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -328,6 +328,9 @@ export function execute(command: cli.ICommand): Promise<void> {
                 case cli.CommandType.deploymentRename:
                     return deploymentRename(<cli.IDeploymentRenameCommand>command);
 
+                case cli.CommandType.promote:
+                    return promote(<cli.IPromoteCommand>command);
+
                 case cli.CommandType.release:
                     return release(<cli.IReleaseCommand>command);
 
@@ -581,6 +584,32 @@ function register(command: cli.IRegisterCommand): Promise<void> {
     initiateExternalAuthenticationAsync(command.serverUrl, "register");
 
     return loginWithAccessTokenInternal(command.serverUrl);
+}
+
+function promote(command: cli.IPromoteCommand): Promise<void> {
+    var appId: string;
+    var sourceDeploymentId: string;
+    var destDeploymentId: string;
+    
+    return getAppId(command.appName)
+        .then((gotAppId: string): Promise<string> => {
+            throwForInvalidAppId(gotAppId, command.appName);
+            appId = gotAppId;
+            return getDeploymentId(appId, command.sourceDeploymentName);
+        })
+        .then((deploymentId: string): Promise<string> => {
+            throwForInvalidDeploymentId(deploymentId, command.sourceDeploymentName, command.appName);
+            sourceDeploymentId = deploymentId;
+            return getDeploymentId(appId, command.destDeploymentName);
+        })
+        .then((deploymentId: string): Promise<void> => {
+            throwForInvalidDeploymentId(deploymentId, command.destDeploymentName, command.appName);
+            destDeploymentId = deploymentId;
+            return sdk.promotePackage(appId, sourceDeploymentId, destDeploymentId);
+        })
+        .then((): void => {
+            log("Promoted deployment \"" + command.sourceDeploymentName + "\" of app \"" + command.appName + "\" to deployment \"" + command.destDeploymentName + "\".");
+        });
 }
 
 function release(command: cli.IReleaseCommand): Promise<void> {

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -152,6 +152,13 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
 
         addCommonConfiguration(yargs);
     })
+    .command("promote", "Promote the package from one deployment of your app to another", (yargs: yargs.Argv) => {
+        yargs.usage(USAGE_PREFIX + " promote <appName> <sourceDeploymentName> <destDeploymentName>")
+            .demand(/*count*/ 4, /*max*/ 4)  // Require exactly four non-option arguments.
+            .example("promote MyApp Staging Production", "Promote the latest \"Staging\" package of \"MyApp\" to \"Production\"");
+            
+        addCommonConfiguration(yargs);
+    })
     .command("deployment", "View and manage the deployments for your apps", (yargs: yargs.Argv) => {
         isValidCommandCategory = true;
         yargs.usage(USAGE_PREFIX + " deployment <command>")
@@ -309,7 +316,6 @@ function createCommand(): cli.ICommand {
                             deploymentListCommand.verbose = argv["verbose"];
                         }
                         break;
-
                     case "remove":
                     case "rm":
                         if (arg2 && arg3) {
@@ -346,6 +352,18 @@ function createCommand(): cli.ICommand {
 
             case "logout":
                 cmd = { type: cli.CommandType.logout };
+                break;
+                
+            case "promote":
+                if (arg1 && arg2 && arg3) {
+                    cmd = { type: cli.CommandType.promote };
+
+                    var deploymentPromoteCommand = <cli.IPromoteCommand>cmd;
+
+                    deploymentPromoteCommand.appName = arg1;
+                    deploymentPromoteCommand.sourceDeploymentName = arg2;
+                    deploymentPromoteCommand.destDeploymentName = arg3;
+                }
                 break;
 
             case "register":

--- a/sdk/script/management/account-manager.ts
+++ b/sdk/script/management/account-manager.ts
@@ -832,6 +832,32 @@ export class AccountManager {
         });
     }
 
+    public promotePackage(appId: string, sourceDeploymentId: string, destDeploymentId: string): Promise<void> {
+        return Promise<void>((resolve, reject, notify) => {
+            var requester = (this._authedAgent ? this._authedAgent : request);
+            var req = requester.post(this.serverUrl + "/apps/" + appId + "/deployments/" + sourceDeploymentId + "/promote/" + destDeploymentId);
+            this.attachCredentials(req, requester);
+            
+            req.end((err: any, res: request.Response) => {
+                if (err) {
+                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
+                    return;
+                }
+
+                if (res.ok) {
+                    resolve(<void>null);
+                } else {
+                    var body = tryJSON(res.text);
+                    if (body) {
+                        reject(<CodePushError>body);
+                    } else {
+                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
+                    }
+                }
+            });
+        });
+    }
+
     public getPackage(appId: string, deploymentId: string): Promise<Package> {
         return Promise<Package>((resolve, reject, notify) => {
             var requester = (this._authedAgent ? this._authedAgent : request);


### PR DESCRIPTION
With this PR, users can now promote packages from one deployment to another with the command:
```
code-push promote <appName> <sourceDeploymentName> <destDeploymentName>
```
One common scenario would be to bump a package from the Staging deployment to the Production deployment, perhaps after tests have been done on Staging and the package is ready to be pushed to all of the end users subscribed to the Production deployment.