### PR TITLE
When running the deployment list command, show the package by default

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -58,7 +58,6 @@ export interface IDeploymentAddCommand extends ICommand {
 export interface IDeploymentListCommand extends ICommand {
     appName: string;
     format: string;
-    verbose?: boolean;
 }
 
 export interface IDeploymentRemoveCommand extends ICommand {

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -86,12 +86,11 @@ function appRemove(commandName: string, yargs: yargs.Argv): void {
 
 function deploymentList(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
-    yargs.usage(USAGE_PREFIX + " deployment " + commandName + " <appName> [--format <format>] [--verbose]")
+    yargs.usage(USAGE_PREFIX + " deployment " + commandName + " <appName> [--format <format>]")
         .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
         .example("deployment " + commandName + " MyApp", "Lists deployments for app \"MyApp\" in tabular format")
         .example("deployment " + commandName + " MyApp --format json", "Lists deployments for app \"MyApp\" in JSON format")
         .option("format", { default: "table", demand: false, description: "The output format (\"json\" or \"table\")", type: "string" })
-        .option("verbose", { alias: "v", demand: false, description: "Show deployment description and package metadata", type: "boolean" })
     addCommonConfiguration(yargs);
 }
 
@@ -338,7 +337,6 @@ function createCommand(): cli.ICommand {
 
                             deploymentListCommand.appName = arg2;
                             deploymentListCommand.format = argv["format"];
-                            deploymentListCommand.verbose = argv["verbose"];
                         }
                         break;
 

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -325,32 +325,11 @@ describe("CLI", () => {
             });
     });
 
-    it("deploymentList lists deployment names and deployment keys", (done: MochaDone): void => {
+    it("deploymentList lists deployment names, deployment keys, and package information", (done: MochaDone): void => {
         var command: cli.IDeploymentListCommand = {
             type: cli.CommandType.deploymentList,
             appName: "a",
             format: "json"
-        };
-
-        cmdexec.execute(command)
-            .done((): void => {
-                sinon.assert.calledOnce(log);
-                assert.equal(log.args[0].length, 1);
-
-                var actual: string = log.args[0][0];
-                var expected = "[{\"name\":\"Production\",\"deploymentKey\":\"6\"},{\"name\":\"Staging\",\"deploymentKey\":\"6\"}]";
-
-                assert.equal(actual, expected);
-                done();
-            });
-    });
-
-    it("deploymentList -v lists deployment names, deployment keys, and package information", (done: MochaDone): void => {
-        var command: cli.IDeploymentListCommand = {
-            type: cli.CommandType.deploymentList,
-            appName: "a",
-            format: "json",
-            verbose: true
         };
 
         cmdexec.execute(command)


### PR DESCRIPTION
And remove the '--verbose'/'-v' options which previously were used to get the package information.