### PR TITLE
Add 'deployment view' command to CLI to show release history

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -10,7 +10,7 @@
     deploymentList,
     deploymentRemove,
     deploymentRename,
-    deploymentView,
+    deploymentHistory,
     login,
     logout,
     promote,
@@ -72,7 +72,7 @@ export interface IDeploymentRenameCommand extends ICommand {
     newDeploymentName: string;
 }
 
-export interface IDeploymentViewCommand extends ICommand {
+export interface IDeploymentHistoryCommand extends ICommand {
     appName: string;
     deploymentName: string;
     format: string;

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -10,6 +10,7 @@
     deploymentList,
     deploymentRemove,
     deploymentRename,
+    deploymentView,
     login,
     logout,
     promote,
@@ -69,6 +70,12 @@ export interface IDeploymentRenameCommand extends ICommand {
     appName: string;
     currentDeploymentName: string;
     newDeploymentName: string;
+}
+
+export interface IDeploymentViewCommand extends ICommand {
+    appName: string;
+    deploymentName: string;
+    format: string;
 }
 
 export interface ILoginCommand extends ICommand {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -283,6 +283,12 @@ function deploymentRename(command: cli.IDeploymentRenameCommand): Promise<void> 
         });
 }
 
+function deploymentView(command: cli.IDeploymentViewCommand): Promise<void> {
+    throwForInvalidOutputFormat(command.format);
+
+    return Q(<void>null);
+}
+
 function deserializeConnectionInfo(): IStandardLoginConnectionInfo|IAccessKeyLoginConnectionInfo {
     var savedConnection: string;
 
@@ -353,6 +359,9 @@ export function execute(command: cli.ICommand): Promise<void> {
 
                 case cli.CommandType.deploymentRename:
                     return deploymentRename(<cli.IDeploymentRenameCommand>command);
+
+                case cli.CommandType.deploymentView:
+                    return deploymentView(<cli.IDeploymentViewCommand>command);
 
                 case cli.CommandType.promote:
                     return promote(<cli.IPromoteCommand>command);

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -601,7 +601,7 @@ function printDeploymentHistory(command: cli.IDeploymentHistoryCommand, packageH
     if (command.format === "json") {
         printJson(packageHistory);
     } else if (command.format === "table") {
-        printTable(["Label", "Uploaded On", "App Store Version", "Mandatory", "Description"], (dataSource: any[]) => {
+        printTable(["Label", "Release Time", "App Store Version", "Mandatory", "Description"], (dataSource: any[]) => {
             packageHistory.forEach((packageObject: Package) => {
                 dataSource.push([
                     packageObject.label,
@@ -625,7 +625,7 @@ function getPackageString(packageObject: Package): string {
         "App Store Version: " + packageObject.appVersion + "\n" +
         "Mandatory: " + (packageObject.isMandatory ? "Yes" : "No") + "\n" +
         "Hash: " + packageObject.packageHash + "\n" + 
-        "Uploaded On: " + new Date(packageObject.uploadTime).toString();
+        "Release Time: " + new Date(packageObject.uploadTime).toString();
 }
 
 function printJson(object: any): void {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -601,14 +601,14 @@ function printDeploymentHistory(command: cli.IDeploymentHistoryCommand, packageH
     if (command.format === "json") {
         printJson(packageHistory);
     } else if (command.format === "table") {
-        printTable(["Label", "Description", "App Store Version", "Mandatory", "Uploaded On"], (dataSource: any[]) => {
+        printTable(["Label", "Uploaded On", "App Store Version", "Mandatory", "Description"], (dataSource: any[]) => {
             packageHistory.forEach((packageObject: Package) => {
                 dataSource.push([
                     packageObject.label,
-                    packageObject.description ? wordwrap(30)(packageObject.description) : "",
+                    new Date(packageObject.uploadTime).toString(),
                     packageObject.appVersion,
                     packageObject.isMandatory ? "Yes" : "No",
-                    new Date(packageObject.uploadTime).toString()
+                    packageObject.description ? wordwrap(30)(packageObject.description) : ""
                 ]);
             });
         });

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -103,12 +103,12 @@ function deploymentRemove(commandName: string, yargs: yargs.Argv): void {
     addCommonConfiguration(yargs);
 }
 
-function deploymentView(commandName: string, yargs: yargs.Argv): void {
+function deploymentHistory(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
     yargs.usage(USAGE_PREFIX + " deployment " + commandName + " <appName> <deploymentName> [--format <format>]")
         .demand(/*count*/ 4, /*max*/ 4)  // Require exactly four non-option arguments.
-        .example("deployment " + commandName + " MyApp MyDeployment", "Views information for deployment \"MyDeployment\" from app \"MyApp\" in tabular format")
-        .example("deployment " + commandName + " MyApp MyDeployment --format json", "Views information for deployment \"MyDeployment\" from app \"MyApp\" in JSON format")
+        .example("deployment " + commandName + " MyApp MyDeployment", "Shows the release history for deployment \"MyDeployment\" from app \"MyApp\" in tabular format")
+        .example("deployment " + commandName + " MyApp MyDeployment --format json", "Shows the release history for deployment \"MyDeployment\" from app \"MyApp\" in JSON format")
         .option("format", { default: "table", demand: false, description: "The output format (\"json\" or \"table\")", type: "string" });
 
     addCommonConfiguration(yargs);
@@ -203,8 +203,8 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             })
             .command("list", "List the deployments associated with an app", (yargs: yargs.Argv) => deploymentList("list", yargs))
             .command("ls", "List the deployments associated with an app", (yargs: yargs.Argv) => deploymentList("ls", yargs))
-            .command("view", "View a specific deployment", (yargs: yargs.Argv) => deploymentView("view", yargs))
-            .command("v", "View a specific deployment", (yargs: yargs.Argv) => deploymentView("v", yargs))
+            .command("history", "Show the release history of a specific deployment", (yargs: yargs.Argv) => deploymentHistory("history", yargs))
+            .command("h", "Show the release history of a specific deployment", (yargs: yargs.Argv) => deploymentHistory("h", yargs))
             .check((argv: any, aliases: { [aliases: string]: string }): any => isValidCommand);  // Report unrecognized, non-hyphenated command category.
 
         addCommonConfiguration(yargs);
@@ -377,16 +377,16 @@ function createCommand(): cli.ICommand {
                         }
                         break;
 
-                    case "view":
-                    case "v":
+                    case "history":
+                    case "h":
                         if (arg2 && arg3) {
-                            cmd = { type: cli.CommandType.deploymentView };
+                            cmd = { type: cli.CommandType.deploymentHistory };
 
-                            var deploymentViewCommand = <cli.IDeploymentViewCommand>cmd;
+                            var deploymentHistoryCommand = <cli.IDeploymentHistoryCommand>cmd;
 
-                            deploymentViewCommand.appName = arg2;
-                            deploymentViewCommand.deploymentName = arg3;
-                            deploymentViewCommand.format = argv["format"];
+                            deploymentHistoryCommand.appName = arg2;
+                            deploymentHistoryCommand.deploymentName = arg3;
+                            deploymentHistoryCommand.format = argv["format"];
                         }
                         break;
                 }

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -90,7 +90,7 @@ function deploymentList(commandName: string, yargs: yargs.Argv): void {
         .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
         .example("deployment " + commandName + " MyApp", "Lists deployments for app \"MyApp\" in tabular format")
         .example("deployment " + commandName + " MyApp --format json", "Lists deployments for app \"MyApp\" in JSON format")
-        .option("format", { default: "table", demand: false, description: "The output format (\"json\" or \"table\")", type: "string" })
+        .option("format", { default: "table", demand: false, description: "The output format (\"json\" or \"table\")", type: "string" });
     addCommonConfiguration(yargs);
 }
 
@@ -99,6 +99,17 @@ function deploymentRemove(commandName: string, yargs: yargs.Argv): void {
     yargs.usage(USAGE_PREFIX + " deployment " + commandName + " <appName> <deploymentName>")
         .demand(/*count*/ 4, /*max*/ 4)  // Require exactly four non-option arguments.
         .example("deployment " + commandName + " MyApp MyDeployment", "Removes deployment \"MyDeployment\" from app \"MyApp\"");
+
+    addCommonConfiguration(yargs);
+}
+
+function deploymentView(commandName: string, yargs: yargs.Argv): void {
+    isValidCommand = true;
+    yargs.usage(USAGE_PREFIX + " deployment " + commandName + " <appName> <deploymentName> [--format <format>]")
+        .demand(/*count*/ 4, /*max*/ 4)  // Require exactly four non-option arguments.
+        .example("deployment " + commandName + " MyApp MyDeployment", "Views information for deployment \"MyDeployment\" from app \"MyApp\" in tabular format")
+        .example("deployment " + commandName + " MyApp MyDeployment --format json", "Views information for deployment \"MyDeployment\" from app \"MyApp\" in JSON format")
+        .option("format", { default: "table", demand: false, description: "The output format (\"json\" or \"table\")", type: "string" });
 
     addCommonConfiguration(yargs);
 }
@@ -192,6 +203,8 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             })
             .command("list", "List the deployments associated with an app", (yargs: yargs.Argv) => deploymentList("list", yargs))
             .command("ls", "List the deployments associated with an app", (yargs: yargs.Argv) => deploymentList("ls", yargs))
+            .command("view", "View a specific deployment", (yargs: yargs.Argv) => deploymentView("view", yargs))
+            .command("v", "View a specific deployment", (yargs: yargs.Argv) => deploymentView("v", yargs))
             .check((argv: any, aliases: { [aliases: string]: string }): any => isValidCommand);  // Report unrecognized, non-hyphenated command category.
 
         addCommonConfiguration(yargs);
@@ -361,6 +374,19 @@ function createCommand(): cli.ICommand {
                             deploymentRenameCommand.appName = arg2;
                             deploymentRenameCommand.currentDeploymentName = arg3;
                             deploymentRenameCommand.newDeploymentName = arg4;
+                        }
+                        break;
+
+                    case "view":
+                    case "v":
+                        if (arg2 && arg3) {
+                            cmd = { type: cli.CommandType.deploymentView };
+
+                            var deploymentViewCommand = <cli.IDeploymentViewCommand>cmd;
+
+                            deploymentViewCommand.appName = arg2;
+                            deploymentViewCommand.deploymentName = arg3;
+                            deploymentViewCommand.format = argv["format"];
                         }
                         break;
                 }

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -94,7 +94,7 @@ export class SdkStub {
                 appVersion: "1.0.0",
                 isMandatory: false,
                 packageHash: "463acc7d06adc9c46233481d87d9e8264b3e9ffe60fe98d721e6974209dc71a0",
-                blobUrl: "https://codepushstaging.blob.core.windows.net/storagev2/416cfQ5Ge",
+                blobUrl: "https://fakeblobstorage.net/storagev2/blobid1",
                 uploadTime: 1447113596270,
                 label: "v1"
             },
@@ -103,7 +103,7 @@ export class SdkStub {
                 appVersion: "1.0.1",
                 isMandatory: false,
                 packageHash: "463acc7d06adc9c46233481d87d9e8264b3e9ffe60fe98d721e6974209dc71a0",
-                blobUrl: "https://codepushstaging.blob.core.windows.net/storagev2/4JpoBE5Gg",
+                blobUrl: "https://fakeblobstorage.net/storagev2/blobid2",
                 uploadTime: 1447118476669,
                 label: "v2"
             }
@@ -172,7 +172,7 @@ describe("CLI", () => {
     });
 
     it("accessKeyList lists access key names and ID's", (done: MochaDone): void => {
-        var command: cli.ICommand = {
+        var command: cli.IAccessKeyListCommand = {
             type: cli.CommandType.accessKeyList,
             format: "json"
         };
@@ -264,7 +264,7 @@ describe("CLI", () => {
     });
 
     it("appList lists app names and ID's", (done: MochaDone): void => {
-        var command: cli.ICommand = {
+        var command: cli.IAppListCommand = {
             type: cli.CommandType.appList,
             format: "json"
         };
@@ -483,7 +483,7 @@ describe("CLI", () => {
                         appVersion: "1.0.1",
                         isMandatory: false,
                         packageHash: "463acc7d06adc9c46233481d87d9e8264b3e9ffe60fe98d721e6974209dc71a0",
-                        blobUrl: "https://codepushstaging.blob.core.windows.net/storagev2/4JpoBE5Gg",
+                        blobUrl: "https://fakeblobstorage.net/storagev2/blobid2",
                         uploadTime: 1447118476669,
                         label: "v2"
                     },
@@ -491,7 +491,7 @@ describe("CLI", () => {
                         appVersion: "1.0.0",
                         isMandatory: false,
                         packageHash: "463acc7d06adc9c46233481d87d9e8264b3e9ffe60fe98d721e6974209dc71a0",
-                        blobUrl: "https://codepushstaging.blob.core.windows.net/storagev2/416cfQ5Ge",
+                        blobUrl: "https://fakeblobstorage.net/storagev2/blobid1",
                         uploadTime: 1447113596270,
                         label: "v1"
                     }

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -460,9 +460,9 @@ describe("CLI", () => {
             });
     });
 
-    it("deploymentView lists package history information", (done: MochaDone): void => {
-        var command: cli.IDeploymentViewCommand = {
-            type: cli.CommandType.deploymentView,
+    it("deploymentHistory lists package history information", (done: MochaDone): void => {
+        var command: cli.IDeploymentHistoryCommand = {
+            type: cli.CommandType.deploymentHistory,
             appName: "a",
             deploymentName: "Staging",
             format: "json"

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -88,6 +88,28 @@ export class SdkStub {
         }]);
     }
 
+    public getPackageHistory(appId: string, deploymentId: string): Promise<codePush.Package[]> {
+        return Q([
+            <codePush.Package>{
+                appVersion: "1.0.0",
+                isMandatory: false,
+                packageHash: "463acc7d06adc9c46233481d87d9e8264b3e9ffe60fe98d721e6974209dc71a0",
+                blobUrl: "https://codepushstaging.blob.core.windows.net/storagev2/416cfQ5Ge",
+                uploadTime: 1447113596270,
+                label: "v1"
+            },
+            <codePush.Package>{
+                description: "New update - this update does a whole bunch of things, including testing linewrapping",
+                appVersion: "1.0.1",
+                isMandatory: false,
+                packageHash: "463acc7d06adc9c46233481d87d9e8264b3e9ffe60fe98d721e6974209dc71a0",
+                blobUrl: "https://codepushstaging.blob.core.windows.net/storagev2/4JpoBE5Gg",
+                uploadTime: 1447118476669,
+                label: "v2"
+            }
+        ]);
+    }
+
     public removeAccessKey(accessKeyId: string): Promise<void> {
         return Q(<void>null);
     }
@@ -434,6 +456,48 @@ describe("CLI", () => {
                 sinon.assert.calledOnce(log);
                 sinon.assert.calledWithExactly(log, "Renamed deployment \"Staging\" to \"c\" for app \"a\".");
 
+                done();
+            });
+    });
+
+    it("deploymentView lists package history information", (done: MochaDone): void => {
+        var command: cli.IDeploymentViewCommand = {
+            type: cli.CommandType.deploymentView,
+            appName: "a",
+            deploymentName: "Staging",
+            format: "json"
+        };
+
+        var getPackageHistory: Sinon.SinonSpy = sandbox.spy(cmdexec.sdk, "getPackageHistory");
+
+        cmdexec.execute(command)
+            .done((): void => {
+                sinon.assert.calledOnce(getPackageHistory);
+                sinon.assert.calledOnce(log);
+                assert.equal(log.args[0].length, 1);
+
+                var actual: string = log.args[0][0];
+                var expected: codePush.Package[] = [
+                    <codePush.Package>{
+                        description: "New update - this update does a whole bunch of things, including testing linewrapping",
+                        appVersion: "1.0.1",
+                        isMandatory: false,
+                        packageHash: "463acc7d06adc9c46233481d87d9e8264b3e9ffe60fe98d721e6974209dc71a0",
+                        blobUrl: "https://codepushstaging.blob.core.windows.net/storagev2/4JpoBE5Gg",
+                        uploadTime: 1447118476669,
+                        label: "v2"
+                    },
+                    <codePush.Package>{
+                        appVersion: "1.0.0",
+                        isMandatory: false,
+                        packageHash: "463acc7d06adc9c46233481d87d9e8264b3e9ffe60fe98d721e6974209dc71a0",
+                        blobUrl: "https://codepushstaging.blob.core.windows.net/storagev2/416cfQ5Ge",
+                        uploadTime: 1447113596270,
+                        label: "v1"
+                    }
+                ];
+
+                assertJsonDescribesObject(actual, expected);
                 done();
             });
     });

--- a/sdk/script/management/account-manager.ts
+++ b/sdk/script/management/account-manager.ts
@@ -899,26 +899,26 @@ export class AccountManager {
             this.attachCredentials(req, requester);
 
             req.end((err: any, res: request.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
+                if (err) {
+                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
+                    return;
+                }
 
-                    var body = tryJSON(res.text);
-                    if (res.ok) {
-                        if (body) {
-                            resolve(body.packageHistory);
-                        } else {
-                            reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                        }
+                var body = tryJSON(res.text);
+                if (res.ok) {
+                    if (body) {
+                        resolve(body.packageHistory);
                     } else {
-                        if (body) {
-                            reject(<CodePushError>body);
-                        } else {
-                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                        }
+                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
                     }
-                });
+                } else {
+                    if (body) {
+                        reject(<CodePushError>body);
+                    } else {
+                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
+                    }
+                }
+            });
         });
     }
 

--- a/sdk/script/management/account-manager.ts
+++ b/sdk/script/management/account-manager.ts
@@ -892,6 +892,36 @@ export class AccountManager {
         });
     }
 
+    public getPackageHistory(appId: string, deploymentId: string): Promise<Package[]> {
+        return Promise<Package[]>((resolve, reject, notify) => {
+            var requester = (this._authedAgent ? this._authedAgent : request);
+            var req = requester.get(this.serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/packageHistory");
+            this.attachCredentials(req, requester);
+
+            req.end((err: any, res: request.Response) => {
+                    if (err) {
+                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
+                        return;
+                    }
+
+                    var body = tryJSON(res.text);
+                    if (res.ok) {
+                        if (body) {
+                            resolve(body.packageHistory);
+                        } else {
+                            reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
+                        }
+                    } else {
+                        if (body) {
+                            reject(<CodePushError>body);
+                        } else {
+                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
+                        }
+                    }
+                });
+        });
+    }
+
     private static getLoginInfo(accessKey: string): ILoginInfo {
         try {
             var decoded: string = base64.decode(accessKey);

--- a/sdk/test/management-sdk.ts
+++ b/sdk/test/management-sdk.ts
@@ -235,6 +235,36 @@ describe("Management SDK", () => {
             done();
         }, rejectHandler);
     });
+
+    it("getPackageHistory handles success response with no packages", (done: MochaDone) => {
+        mockReturn(JSON.stringify({ packageHistory: [] }), 200);
+
+        manager.getPackageHistory("appId", "deploymentId").done((obj: any) => {
+            assert.ok(obj);
+            assert.equal(obj.length, 0);
+            done();
+        }, rejectHandler);
+    });
+
+    it("getPackageHistory handles success response with two packages", (done: MochaDone) => {
+        mockReturn(JSON.stringify({ packageHistory: [ { label: "v1" }, { label: "v2" } ] }), 200);
+
+        manager.getPackageHistory("appId", "deploymentId").done((obj: any) => {
+            assert.ok(obj);
+            assert.equal(obj.length, 2);
+            assert.equal(obj[0].label, "v1");
+            assert.equal(obj[1].label, "v2");
+            done();
+        }, rejectHandler);
+    });
+
+    it("getPackageHistory handles error response", (done: MochaDone) => {
+        mockReturn("", 404);
+
+        manager.getPackageHistory("appId", "deploymentId").done((obj: any) => {
+            throw new Error("Call should not complete successfully");
+        }, (error: Error) => done());
+    });
 });
 
 // Helper method that is used everywhere that an assert.fail() is needed in a promise handler


### PR DESCRIPTION
Here is how it currently looks, I am very open to feedback:

![image](https://cloud.githubusercontent.com/assets/696206/11052384/4a1ae428-870c-11e5-9f7c-5f68997bab46.png)

Thoughts:
1. Are we happy with the syntax of the command?
2. The 'description' field is not mandatory when you call the 'release' command, hence I wouldn't be surprised if it was empty most of the time. Brainstorm: Make it a compulsory argument to 'release'? Hide the 'description' column if it is completely empty? Leave it as-is?
3. For deployments with no releases, I'm not sure if the output is confusing. Should I use a custom string?