### PR TITLE
Update README to document the 'deployment history' command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -157,7 +157,7 @@ code-push promote MyApp Staging Production
 
 ### Viewing release history
 
-You can view a history of your releases using the following command:
+You can view a history of releases for a specific app deployment (including promotions) using the following command:
 
 ```
 code-push deployment history <appName> <deploymentName>

--- a/cli/README.md
+++ b/cli/README.md
@@ -119,6 +119,12 @@ code-push release <appName> <package> <appStoreVersion>
 [--mandatory]
 ```
 
+You can view a history of your updates using the following command:
+
+```
+code-push deployment history <appName> <deploymentName>
+```
+
 #### Package parameter
 
 You can specify either a single file (e.g. a JS bundle for a React Native app), or a path to a directory (e.g. the /platforms/ios/www folder for a Cordova app). You don't need to zip up multiple files or directories in order to deploy those changes. The CLI will automatically zip them for you.

--- a/cli/README.md
+++ b/cli/README.md
@@ -119,12 +119,6 @@ code-push release <appName> <package> <appStoreVersion>
 [--mandatory]
 ```
 
-You can view a history of your updates using the following command:
-
-```
-code-push deployment history <appName> <deploymentName>
-```
-
 #### Package parameter
 
 You can specify either a single file (e.g. a JS bundle for a React Native app), or a path to a directory (e.g. the /platforms/ios/www folder for a Cordova app). You don't need to zip up multiple files or directories in order to deploy those changes. The CLI will automatically zip them for you.
@@ -159,4 +153,12 @@ Once you've tested an update to a specific deployment, and you want to promote i
 ```
 code-push promote <appName> <sourceDeploymentName> <destDeploymentName>
 code-push promote MyApp Staging Production
+```
+
+### Viewing release history
+
+You can view a history of your releases using the following command:
+
+```
+code-push deployment history <appName> <deploymentName>
 ```


### PR DESCRIPTION
Forgot to do this earlier. Two thoughts:
- Is the section this is in a little strange?
- Does the 'history' command actually belong under 'deployment'?