### PR TITLE
Bumping the SDK and CLI to v1.2.0-beta

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push-cli",
-  "version": "1.1.2-beta",
+  "version": "1.2.0-beta",
   "description": "Management CLI for the CodePush service",
   "main": "script/cli.js",
   "scripts": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "1.1.1-beta",
+  "version": "1.2.0-beta",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/plugin.xml
+++ b/sdk/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="code-push" version="1.1.1-beta">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="code-push" version="1.2.0-beta">
 	<name>CodePushAcquisition</name>
 	<description>CodePush Acquisition Plugin for Apache Cordova</description>
 	<license>MIT</license>


### PR DESCRIPTION
I'm planning to release an update of the CLI and SDK this afternoon, so this change simply bumps their respective versions.