### PR TITLE
Cli improvements

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -164,7 +164,9 @@ function appList(command: cli.IAppListCommand): Promise<void> {
                     .then((deployments: Deployment[]) => {
                         var deploymentList: string = deployments
                             .map((deployment: Deployment) => deployment.name)
-                            .sort()
+                            .sort((first: string, second: string) => {
+                                return first.toLowerCase().localeCompare(second.toLowerCase());
+                            })
                             .join(", ");
                         return deploymentList;
                     });

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -10,6 +10,7 @@ import * as path from "path";
 var prompt = require("prompt");
 import * as Q from "q";
 import * as recursiveFs from "recursive-fs";
+import * as semver from "semver";
 import slash = require("slash");
 import tryJSON = require("try-json");
 var Table = require("cli-table");
@@ -728,6 +729,10 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
 }
 
 function release(command: cli.IReleaseCommand): Promise<void> {
+    if (semver.valid(command.appStoreVersion) === null) {
+        throw new Error("Please use a semver compliant app store version, for example \"1.0.3\".");
+    }
+
     return getAppId(command.appName)
         .then((appId: string): Promise<void> => {
             throwForInvalidAppId(appId, command.appName);

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -157,23 +157,22 @@ function appList(command: cli.IAppListCommand): Promise<void> {
     var apps: App[];
 
     return sdk.getApps()
-        .then((retrievedApps: App[]): Promise<string[]> => {
+        .then((retrievedApps: App[]): Promise<string[][]> => {
             apps = retrievedApps;
-            var deploymentListPromises: Promise<string>[] = apps.map((app: App) => {
+            var deploymentListPromises: Promise<string[]>[] = apps.map((app: App) => {
                 return sdk.getDeployments(app.id)
                     .then((deployments: Deployment[]) => {
-                        var deploymentList: string = deployments
+                        var deploymentList: string[] = deployments
                             .map((deployment: Deployment) => deployment.name)
                             .sort((first: string, second: string) => {
                                 return first.toLowerCase().localeCompare(second.toLowerCase());
-                            })
-                            .join(", ");
+                            });
                         return deploymentList;
                     });
             });
             return Q.all(deploymentListPromises);
         })
-        .then((deploymentLists: string[]): void => {
+        .then((deploymentLists: string[][]): void => {
             printAppList(command.format, apps, deploymentLists);
         });
 }
@@ -587,7 +586,7 @@ function formatDate(unixOffset: number): string {
     }
 }
 
-function printAppList(format: string, apps: App[], deploymentLists: string[]): void {
+function printAppList(format: string, apps: App[], deploymentLists: string[][]): void {
     if (format === "json") {
         var dataSource: any[] = apps.map((app: App, index: number) => {
             return { "name": app.name, "deployments": deploymentLists[index] };
@@ -597,7 +596,7 @@ function printAppList(format: string, apps: App[], deploymentLists: string[]): v
         var headers = ["Name", "Deployments"];
         printTable(headers, (dataSource: any[]): void => {
             apps.forEach((app: App, index: number): void => {
-                var row = [app.name, wordwrap(50)(deploymentLists[index])];
+                var row = [app.name, wordwrap(50)(deploymentLists[index].join(", "))];
                 dataSource.push(row);
             });
         });

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -597,7 +597,7 @@ function printAppList(format: string, apps: App[], deploymentLists: string[]): v
         var headers = ["Name", "Deployments"];
         printTable(headers, (dataSource: any[]): void => {
             apps.forEach((app: App, index: number): void => {
-                var row = [app.name, deploymentLists[index]];
+                var row = [app.name, wordwrap(50)(deploymentLists[index])];
                 dataSource.push(row);
             });
         });
@@ -637,7 +637,6 @@ function printDeploymentHistory(command: cli.IDeploymentHistoryCommand, packageH
                 }
 
                 if (releaseSource) {
-                    // Need to word-wrap internally because wordwrap is not smart enough to ignore color characters
                     releaseTime += "\n" + chalk.magenta(`(${releaseSource})`).toString();
                 }
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -1,6 +1,5 @@
 ﻿import * as yargs from "yargs";
 import * as cli from "../definitions/cli";
-import * as semver from "semver";
 import * as chalk from "chalk";
 
 const USAGE_PREFIX = "Usage: code-push";
@@ -164,11 +163,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .example("release MyApp ./platforms/ios/www 1.0.3 -d Production", "Upload the \"./platforms/ios/www\" folder and all its contents to the \"Production\" deployment for app \"MyApp\" with the required semver compliant app store version of 1.0.3")
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "The deployment to publish the update to", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
-            .option("mandatory", { alias: "m", default: false, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" })
-            .check((argv: any, aliases: { [alias: string]: string }) => {
-                var appStoreVersion: string = argv._[3];
-                return semver.valid(appStoreVersion) !== null;
-            });
+            .option("mandatory", { alias: "m", default: false, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" });
 
         addCommonConfiguration(yargs);
     })

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -276,8 +276,8 @@ describe("CLI", () => {
 
                 var actual: string = log.args[0][0];
                 var expected = [
-                    { name: "a", id: "1" },
-                    { name: "b", id: "2" }
+                    { name: "a", deployments: "Production, Staging" },
+                    { name: "b", deployments: "Production, Staging" }
                 ];
 
                 assertJsonDescribesObject(actual, expected);

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -276,8 +276,8 @@ describe("CLI", () => {
 
                 var actual: string = log.args[0][0];
                 var expected = [
-                    { name: "a", deployments: "Production, Staging" },
-                    { name: "b", deployments: "Production, Staging" }
+                    { name: "a", deployments: ["Production", "Staging"] },
+                    { name: "b", deployments: ["Production", "Staging"] }
                 ];
 
                 assertJsonDescribesObject(actual, expected);


### PR DESCRIPTION
1. Tidying - use .map() instead of [declare array] -> [forEach] -> [push to array]
2. For the 'app list' command, remove the 'id' column and add a 'Deployments' column with a comma-separated list of deployments
3. Clean up the error message when releasing with a non-semver compliant app store version as in #63

Screenshots:
(Very similar to what actually happened when I was testing)
![image](https://cloud.githubusercontent.com/assets/696206/11355423/e1aba888-9209-11e5-9bae-49e9723882d0.png)

('app list' command at the top, not sure if we should bother clarifying the error message in the second command)
![image](https://cloud.githubusercontent.com/assets/696206/11355469/ffa59c5e-9209-11e5-9fe4-980fb2dfbf1f.png)

