### PR TITLE
Fix unzipping errors

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -19,9 +19,11 @@ import wordwrap = require("wordwrap");
 
 import * as cli from "../definitions/cli";
 import { AccessKey, AccountManager, App, Deployment, DeploymentKey, Package } from "code-push";
+var packageJson = require("../package.json");
 import Promise = Q.Promise;
 
 var configFilePath: string = path.join(process.env.LOCALAPPDATA || process.env.HOME, ".code-push.config");
+var userAgent: string = packageJson.name + "/" + packageJson.version;
 
 interface IStandardLoginConnectionInfo {
     accessKeyName: string;
@@ -49,7 +51,7 @@ export var loginWithAccessToken = (): Promise<void> => {
         return Q.fcall(() => { throw new Error("You are not currently logged in. Run the 'code-push login' command to authenticate with the CodePush server."); });
     }
 
-    sdk = new AccountManager(connectionInfo.serverUrl);
+    sdk = new AccountManager(connectionInfo.serverUrl, userAgent);
 
     var accessToken: string;
 
@@ -505,7 +507,7 @@ function initiateExternalAuthenticationAsync(serverUrl: string, action: string):
 function login(command: cli.ILoginCommand): Promise<void> {
     // Check if one of the flags were provided.
     if (command.accessKey) {
-        sdk = new AccountManager(command.serverUrl);
+        sdk = new AccountManager(command.serverUrl, userAgent);
         return sdk.loginWithAccessToken(command.accessKey)
             .then((): void => {
                 // The access token is valid.
@@ -530,7 +532,7 @@ function loginWithAccessTokenInternal(serverUrl: string): Promise<void> {
                 throw new Error("Invalid access token.");
             }
 
-            sdk = new AccountManager(serverUrl);
+            sdk = new AccountManager(serverUrl, userAgent);
 
             return sdk.loginWithAccessToken(accessToken)
                 .then((): void => {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -734,7 +734,9 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
 }
 
 function release(command: cli.IReleaseCommand): Promise<void> {
-    if (semver.valid(command.appStoreVersion) === null) {
+    if (command.package.search(/\.zip$/) !== -1) {
+        throw new Error("It is unnecessary to package releases in a .zip file. Please specify the path of the desired directory or file directly.");
+    } else if (semver.valid(command.appStoreVersion) === null) {
         throw new Error("Please use a semver compliant app store version, for example \"1.0.3\".");
     }
 

--- a/sdk/script/management/account-manager.ts
+++ b/sdk/script/management/account-manager.ts
@@ -41,6 +41,7 @@ interface ILoginInfo {
 export class AccountManager {
     private _authedAgent: request.SuperAgent<any>;
     private _saveAuthedAgent: boolean = false;
+    private _userAgent: string;
 
     public account: Account;
     public serverUrl: string = "http://localhost:3000";
@@ -49,10 +50,11 @@ export class AccountManager {
         return this.account.id;
     }
 
-    constructor(serverUrl?: string) {
+    constructor(serverUrl: string, userAgent: string) {
         // If window is not defined, it means we are in the node environment and not a browser.
         this._saveAuthedAgent = (typeof window === "undefined");
 
+        this._userAgent = userAgent;
         this.serverUrl = serverUrl;
     }
 
@@ -955,6 +957,10 @@ export class AccountManager {
             }
         } else {
             request.withCredentials();
+        }
+
+        if (this._userAgent) {
+            request.set("User-Agent", this._userAgent);
         }
     }
 

--- a/sdk/test/management-sdk.ts
+++ b/sdk/test/management-sdk.ts
@@ -11,7 +11,7 @@ var manager: AccountManager;
 describe("Management SDK", () => {
 
     beforeEach(() => {
-        manager = new AccountManager("http://localhost");
+        manager = new AccountManager(/*serverUrl=*/ "http://localhost", /*userAgent=*/ "unit-test/1.0.0");
     });
 
     after(() => {


### PR DESCRIPTION
We have been logging server errors in our unzip module, and it is highly likely that the cause is users who are uploading their own .zip files. The CLI will zip up a folder for you if you specify the path, but it will leave single files unchanged.

To address this:
1. Modify the CLI to reject .zip uploads with a helpful error message explaining that the user should specify the directory directly (feedback on the error message welcome).
2. Currently it would be impossible to track whether this fixed the issue or not as older CLI versions will still generate these errors. So, send the CLI version in the User-Agent header with every request so that we can track which CLI versions are generating the errors on the server side (also this is just generally useful for telemetry).