### PR TITLE
Code push Cli npm update notification

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -24,10 +24,10 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "code-push": "1.2.0-beta",
     "base-64": "^0.1.0",
     "chalk": "^1.1.0",
     "cli-table": "^0.3.1",
+    "code-push": "1.2.0-beta",
     "fs": "0.0.2",
     "moment": "^2.10.6",
     "opener": "^1.4.1",
@@ -37,6 +37,7 @@
     "semver": "4.3.6",
     "slash": "1.0.0",
     "try-json": "^1.0.0",
+    "update-notifier": "^0.5.0",
     "wordwrap": "1.0.0",
     "yargs": "^3.15.0",
     "yazl": "2.2.2"

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -1,7 +1,9 @@
 ﻿import * as yargs from "yargs";
 import * as cli from "../definitions/cli";
 import * as chalk from "chalk";
+import * as updateNotifier from "update-notifier";
 
+var pkg = require("../package.json");
 const USAGE_PREFIX = "Usage: code-push";
 const CODE_PUSH_URL = "https://codepush.azurewebsites.net";
 
@@ -21,10 +23,18 @@ export function showHelp(showRootDescription?: boolean): void {
             console.log(chalk.cyan("======================================"));
             console.log("");
             console.log("CodePush is a service that allows you to publish mobile app updates directly to your users' devices.\n");
+            updateCheck();
         }
-        
+
         yargs.showHelp();
         wasHelpShown = true;
+    }
+}
+
+function updateCheck() {
+    var notifier = updateNotifier({ pkg });
+    if (notifier.update) {
+        notifier.notify();
     }
 }
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -31,7 +31,7 @@ export function showHelp(showRootDescription?: boolean): void {
     }
 }
 
-function updateCheck() {
+function updateCheck(): void {
     var notifier: updateNotifier.IResult = updateNotifier({ packageJson });
     if (notifier.update) {
         notifier.notify();

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -3,7 +3,7 @@ import * as cli from "../definitions/cli";
 import * as chalk from "chalk";
 import * as updateNotifier from "update-notifier";
 
-var pkg = require("../package.json");
+var packageJson = require("../package.json");
 const USAGE_PREFIX = "Usage: code-push";
 const CODE_PUSH_URL = "https://codepush.azurewebsites.net";
 
@@ -32,7 +32,7 @@ export function showHelp(showRootDescription?: boolean): void {
 }
 
 function updateCheck() {
-    var notifier = updateNotifier({ pkg });
+    var notifier: updateNotifier.IResult = updateNotifier({ packageJson });
     if (notifier.update) {
         notifier.notify();
     }

--- a/tsd.json
+++ b/tsd.json
@@ -78,6 +78,9 @@
     },
     "moment/moment-node.d.ts": {
       "commit": "708609e0764daeb5eb64104af7aca50c520c4e6e"
+    },
+    "update-notifier/update-notifier.d.ts": {
+      "commit": "715df764419937a75a25dcd76bfc954157bc7b96"
     }
   }
 }


### PR DESCRIPTION
Added update-notifier library to give notification when we have a new update to the cli npm package.

This is how it looks:
![screen shot 2015-12-02 at 5 40 25 pm](https://cloud.githubusercontent.com/assets/1646506/11549712/6b1dcd8e-991d-11e5-9ed3-37e7ff01d90c.png)
