### PR TITLE
CLI rollback feature

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -14,9 +14,9 @@
     login,
     logout,
     promote,
-    rollback,
     register,
-    release
+    release,
+    rollback
 }
 
 export interface ICommand {
@@ -94,11 +94,6 @@ export interface IPromoteCommand extends ICommand {
     destDeploymentName: string;
 }
 
-export interface IRollbackCommand extends ICommand {
-    appName: string;
-    deploymentName: string;
-}
-
 export interface IRegisterCommand extends ICommand {
     serverUrl: string;
 }
@@ -110,4 +105,9 @@ export interface IReleaseCommand extends ICommand {
     mandatory: boolean;
     appStoreVersion: string;
     package: string;
+}
+
+export interface IRollbackCommand extends ICommand {
+    appName: string;
+    deploymentName: string;
 }

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -14,6 +14,7 @@
     login,
     logout,
     promote,
+    rollback,
     register,
     release
 }
@@ -91,6 +92,11 @@ export interface IPromoteCommand extends ICommand {
     appName: string;
     sourceDeploymentName: string;
     destDeploymentName: string;
+}
+
+export interface IRollbackCommand extends ICommand {
+    appName: string;
+    deploymentName: string;
 }
 
 export interface IRegisterCommand extends ICommand {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -642,7 +642,9 @@ function printDeploymentHistory(command: cli.IDeploymentHistoryCommand, packageH
                 if (packageObject.releaseMethod === "Promote") {
                     releaseSource = `Promoted ${ packageObject.originalLabel } from "${ packageObject.originalDeployment }"`;
                 } else if (packageObject.releaseMethod === "Rollback") {
-                    releaseSource = `Rolled back to ${ packageObject.originalLabel }`;
+                    var labelNumber: number = parseInt(packageObject.label.substring(1));
+                    var lastLabel: string = "v" + (labelNumber - 1);
+                    releaseSource = `Rolled back ${ lastLabel } to ${ packageObject.originalLabel }`;
                 }
 
                 if (releaseSource) {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -401,11 +401,11 @@ export function execute(command: cli.ICommand): Promise<void> {
                 case cli.CommandType.promote:
                     return promote(<cli.IPromoteCommand>command);
 
-                case cli.CommandType.rollback:
-                    return rollback(<cli.IRollbackCommand>command);
-
                 case cli.CommandType.release:
                     return release(<cli.IReleaseCommand>command);
+
+                case cli.CommandType.rollback:
+                    return rollback(<cli.IRollbackCommand>command);
 
                 default:
                     // We should never see this message as invalid commands should be caught by the argument parser.
@@ -738,24 +738,6 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
         });
 }
 
-function rollback(command: cli.IRollbackCommand): Promise<void> {
-    var appId: string;
-
-    return getAppId(command.appName)
-        .then((appIdResult: string): Promise<string> => {
-            throwForInvalidAppId(appIdResult, command.appName);
-            appId = appIdResult;
-            return getDeploymentId(appId, command.deploymentName);
-        })
-        .then((deploymentId: string): Promise<void> => {
-            throwForInvalidDeploymentId(deploymentId, command.deploymentName, command.appName);
-            return sdk.rollbackPackage(appId, deploymentId);
-        })
-        .then((): void => {
-            log("Successfully performed a rollback on the \"" + command.deploymentName + "\" deployment of the \"" + command.appName + "\" app.");
-        });
-}
-
 function release(command: cli.IReleaseCommand): Promise<void> {
     if (command.package.search(/\.zip$/i) !== -1) {
         throw new Error("It is unnecessary to package releases in a .zip file. Please specify the path of the desired directory or file directly.");
@@ -830,6 +812,24 @@ function release(command: cli.IReleaseCommand): Promise<void> {
                                 });
                         });
                 });
+        });
+}
+
+function rollback(command: cli.IRollbackCommand): Promise<void> {
+    var appId: string;
+
+    return getAppId(command.appName)
+        .then((appIdResult: string): Promise<string> => {
+            throwForInvalidAppId(appIdResult, command.appName);
+            appId = appIdResult;
+            return getDeploymentId(appId, command.deploymentName);
+        })
+        .then((deploymentId: string): Promise<void> => {
+            throwForInvalidDeploymentId(deploymentId, command.deploymentName, command.appName);
+            return sdk.rollbackPackage(appId, deploymentId);
+        })
+        .then((): void => {
+            log("Successfully performed a rollback on the \"" + command.deploymentName + "\" deployment of the \"" + command.appName + "\" app.");
         });
 }
 

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -401,6 +401,9 @@ export function execute(command: cli.ICommand): Promise<void> {
                 case cli.CommandType.promote:
                     return promote(<cli.IPromoteCommand>command);
 
+                case cli.CommandType.rollback:
+                    return rollback(<cli.IRollbackCommand>command);
+
                 case cli.CommandType.release:
                     return release(<cli.IReleaseCommand>command);
 
@@ -732,6 +735,24 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
         })
         .then((): void => {
             log("Successfully promoted the \"" + command.sourceDeploymentName + "\" deployment of the \"" + command.appName + "\" app to the \"" + command.destDeploymentName + "\" deployment.");
+        });
+}
+
+function rollback(command: cli.IRollbackCommand): Promise<void> {
+    var appId: string;
+
+    return getAppId(command.appName)
+        .then((appIdResult: string): Promise<string> => {
+            throwForInvalidAppId(appIdResult, command.appName);
+            appId = appIdResult;
+            return getDeploymentId(appId, command.deploymentName);
+        })
+        .then((deploymentId: string): Promise<void> => {
+            throwForInvalidDeploymentId(deploymentId, command.deploymentName, command.appName);
+            return sdk.rollbackPackage(appId, deploymentId);
+        })
+        .then((): void => {
+            log("Successfully performed a rollback on the \"" + command.deploymentName + "\" deployment of the \"" + command.appName + "\" app.");
         });
 }
 

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -820,18 +820,26 @@ function release(command: cli.IReleaseCommand): Promise<void> {
 function rollback(command: cli.IRollbackCommand): Promise<void> {
     var appId: string;
 
-    return getAppId(command.appName)
-        .then((appIdResult: string): Promise<string> => {
-            throwForInvalidAppId(appIdResult, command.appName);
-            appId = appIdResult;
-            return getDeploymentId(appId, command.deploymentName);
-        })
-        .then((deploymentId: string): Promise<void> => {
-            throwForInvalidDeploymentId(deploymentId, command.deploymentName, command.appName);
-            return sdk.rollbackPackage(appId, deploymentId);
-        })
-        .then((): void => {
-            log("Successfully performed a rollback on the \"" + command.deploymentName + "\" deployment of the \"" + command.appName + "\" app.");
+    return confirm()
+        .then((wasConfirmed: boolean) => {
+            if (!wasConfirmed) {
+                log("Rollback cancelled.")
+                return;
+            }
+
+            return getAppId(command.appName)
+                .then((appIdResult: string): Promise<string> => {
+                    throwForInvalidAppId(appIdResult, command.appName);
+                    appId = appIdResult;
+                    return getDeploymentId(appId, command.deploymentName);
+                })
+                .then((deploymentId: string): Promise<void> => {
+                    throwForInvalidDeploymentId(deploymentId, command.deploymentName, command.appName);
+                    return sdk.rollbackPackage(appId, deploymentId);
+                })
+                .then((): void => {
+                    log("Successfully performed a rollback on the \"" + command.deploymentName + "\" deployment of the \"" + command.appName + "\" app.");
+                });
         });
 }
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -184,6 +184,13 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             
         addCommonConfiguration(yargs);
     })
+    .command("rollback", "Performs a rollback on the latest package of a specific deployment", (yargs: yargs.Argv) => {
+        yargs.usage(USAGE_PREFIX + " rollback <appName> <deploymentName>")
+            .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
+            .example("rollback MyApp Production", "Perform a rollback on the \"Production\" deployment of \"MyApp\"");
+            
+        addCommonConfiguration(yargs);
+    })
     .command("deployment", "View and manage the deployments for your apps", (yargs: yargs.Argv) => {
         isValidCommandCategory = true;
         yargs.usage(USAGE_PREFIX + " deployment <command>")
@@ -412,7 +419,7 @@ function createCommand(): cli.ICommand {
                 
                 logoutCommand.isLocal = argv["local"];
                 break;
-                
+
             case "promote":
                 if (arg1 && arg2 && arg3) {
                     cmd = { type: cli.CommandType.promote };
@@ -422,6 +429,17 @@ function createCommand(): cli.ICommand {
                     deploymentPromoteCommand.appName = arg1;
                     deploymentPromoteCommand.sourceDeploymentName = arg2;
                     deploymentPromoteCommand.destDeploymentName = arg3;
+                }
+                break;
+
+            case "rollback":
+                if (arg1 && arg2) {
+                    cmd = { type: cli.CommandType.rollback };
+
+                    var deploymentRollbackCommand = <cli.IRollbackCommand>cmd;
+
+                    deploymentRollbackCommand.appName = arg1;
+                    deploymentRollbackCommand.deploymentName = arg2;
                 }
                 break;
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -432,17 +432,6 @@ function createCommand(): cli.ICommand {
                 }
                 break;
 
-            case "rollback":
-                if (arg1 && arg2) {
-                    cmd = { type: cli.CommandType.rollback };
-
-                    var deploymentRollbackCommand = <cli.IRollbackCommand>cmd;
-
-                    deploymentRollbackCommand.appName = arg1;
-                    deploymentRollbackCommand.deploymentName = arg2;
-                }
-                break;
-
             case "register":
                 cmd = { type: cli.CommandType.register };
 
@@ -463,6 +452,17 @@ function createCommand(): cli.ICommand {
                     releaseCommand.deploymentName = argv["deploymentName"];
                     releaseCommand.description = argv["description"];
                     releaseCommand.mandatory = argv["mandatory"];
+                }
+                break;
+
+            case "rollback":
+                if (arg1 && arg2) {
+                    cmd = { type: cli.CommandType.rollback };
+
+                    var deploymentRollbackCommand = <cli.IRollbackCommand>cmd;
+
+                    deploymentRollbackCommand.appName = arg1;
+                    deploymentRollbackCommand.deploymentName = arg2;
                 }
                 break;
         }

--- a/sdk/script/management/account-manager.ts
+++ b/sdk/script/management/account-manager.ts
@@ -864,6 +864,32 @@ export class AccountManager {
         });
     }
 
+    public rollbackPackage(appId: string, deploymentId: string): Promise<void> {
+        return Promise<void>((resolve, reject, notify) => {
+            var requester = (this._authedAgent ? this._authedAgent : request);
+            var req = requester.post(this.serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/rollback");
+            this.attachCredentials(req, requester);
+
+            req.end((err: any, res: request.Response) => {
+                if (err) {
+                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
+                    return;
+                }
+
+                if (res.ok) {
+                    resolve(<void>null);
+                } else {
+                    var body = tryJSON(res.text);
+                    if (body) {
+                        reject(<CodePushError>body);
+                    } else {
+                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
+                    }
+                }
+            });
+        });
+    }
+
     public getPackage(appId: string, deploymentId: string): Promise<Package> {
         return Promise<Package>((resolve, reject, notify) => {
             var requester = (this._authedAgent ? this._authedAgent : request);


### PR DESCRIPTION
This feature allows you to undo your most recent release if you have shipped a broken or unintended update. It is equivalent to performing a new release with the same package contents and metadata as the release preceding your most recent one.

For performance and simplicity reasons this feature is implemented on the server side, with the implementation here being a simple POST request. In future, there is quite a lot of duplication and boilerplate in this project that can probably be refactored out (not the highest priority right now).