### PR TITLE
Remove dead deploymentKey methods

### DIFF
--- a/sdk/script/management/account-manager.ts
+++ b/sdk/script/management/account-manager.ts
@@ -651,42 +651,6 @@ export class AccountManager {
         });
     }
 
-    // Deployment key
-    public addDeploymentKey(appId: string, deploymentId: string, name: string, description?: string): Promise<DeploymentKey> {
-        return Promise<DeploymentKey>((resolve, reject, notify) => {
-            var deploymentKey: DeploymentKey = this.generateDeploymentKey(name, description, /*isPrimary*/ false);
-            var requester = (this._authedAgent ? this._authedAgent : request);
-            var req = requester.post(this.serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/deploymentKeys")
-            this.attachCredentials(req, requester);
-
-            req.set("Content-Type", "application/json;charset=UTF-8")
-                .send(JSON.stringify(deploymentKey))
-                .end((err: any, res: request.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
-
-                    if (res.ok) {
-                        var body = tryJSON(res.text);
-                        if (res.ok) {
-                            if (body) {
-                                resolve(body.deploymentKey);
-                            } else {
-                                reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                            }
-                        } else {
-                            if (body) {
-                                reject(<CodePushError>body);
-                            } else {
-                                reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                            }
-                        }
-                    }
-                });
-        });
-    }
-
     public getDeploymentKeys(appId: string, deploymentId: string): Promise<DeploymentKey[]> {
         return Promise<DeploymentKey[]>((resolve, reject, notify) => {
             var requester = (this._authedAgent ? this._authedAgent : request);
@@ -694,111 +658,26 @@ export class AccountManager {
             this.attachCredentials(req, requester);
 
             req.end((err: any, res: request.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
+                if (err) {
+                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
+                    return;
+                }
 
-                    var body = tryJSON(res.text);
-                    if (res.ok) {
-                        if (body) {
-                            resolve(body.deploymentKeys);
-                        } else {
-                            reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                        }
+                var body = tryJSON(res.text);
+                if (res.ok) {
+                    if (body) {
+                        resolve(body.deploymentKeys);
                     } else {
-                        if (body) {
-                            reject(<CodePushError>body);
-                        } else {
-                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                        }
+                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
                     }
-                });
-        });
-    }
-
-    public getDeploymentKey(appId: string, deploymentId: string, deploymentKeyId: string): Promise<DeploymentKey> {
-        return Promise<DeploymentKey>((resolve, reject, notify) => {
-            var requester = (this._authedAgent ? this._authedAgent : request);
-            var req = requester.get(this.serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/deploymentKeys/" + deploymentKeyId)
-            this.attachCredentials(req, requester);
-
-            req.end((err: any, res: request.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
-
-                    var body = tryJSON(res.text);
-                    if (res.ok) {
-                        if (body) {
-                            resolve(body.deploymentKey);
-                        } else {
-                            reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                        }
+                } else {
+                    if (body) {
+                        reject(<CodePushError>body);
                     } else {
-                        if (body) {
-                            reject(<CodePushError>body);
-                        } else {
-                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                        }
+                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
                     }
-                });
-        });
-    }
-
-    public updateDeploymentKey(appId: string, deploymentId: string, deploymentKeyId: string, infoToChange: any): Promise<void> {
-        return Promise<void>((resolve, reject, notify) => {
-            var requester = (this._authedAgent ? this._authedAgent : request);
-            var req = requester.put(this.serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/deploymentKeys/" + deploymentKeyId)
-            this.attachCredentials(req, requester);
-
-            req.set("Content-Type", "application/json;charset=UTF-8")
-                .send(JSON.stringify(infoToChange))
-                .end((err: any, res: request.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
-
-                    if (res.ok) {
-                        resolve(null);
-                    } else {
-                        var body = tryJSON(res.text);
-                        if (body) {
-                            reject(<CodePushError>body);
-                        } else {
-                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                        }
-                    }
-                });
-        });
-    }
-
-    public deleteDeploymentKey(appId: string, deploymentId: string, deploymentKey: DeploymentKey | string): Promise<void> {
-        var id: string = (typeof deploymentKey === "string") ? deploymentKey : deploymentKey.id;
-        return Promise<void>((resolve, reject, notify) => {
-            var requester = (this._authedAgent ? this._authedAgent : request);
-            var req = requester.del(this.serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/deploymentKeys/" + id)
-            this.attachCredentials(req, requester);
-
-            req.end((err: any, res: request.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
-
-                    if (res.ok) {
-                        resolve(null);
-                    } else {
-                        var body = tryJSON(res.text);
-                        if (body) {
-                            reject(<CodePushError>body);
-                        } else {
-                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                        }
-                    }
-                });
+                }
+            });
         });
     }
 

--- a/sdk/test/management-sdk.ts
+++ b/sdk/test/management-sdk.ts
@@ -34,9 +34,7 @@ describe("Management SDK", () => {
             manager.updateDeployment.bind(manager, "appId", { id: "deploymentToChange" }),
             manager.removeDeployment.bind(manager, "appId", { id: "deploymentToChange" }),
 
-            manager.getDeploymentKey.bind(manager, "appId", "deploymentId", "deploymentKeyId"),
             manager.getDeploymentKeys.bind(manager, "appId", "deploymentId"),
-            manager.updateDeploymentKey.bind(manager, "appId", "deploymentId", "deploymentKeyId", {}),
 
             manager.getPackage.bind(manager, ""),
             manager.logout.bind(manager),
@@ -191,38 +189,11 @@ describe("Management SDK", () => {
         }, rejectHandler);
     });
 
-    it("getDeploymentKey handles JSON response", (done: MochaDone) => {
-        mockReturn(JSON.stringify({ deploymentKey: {} }), 200, {});
-
-        manager.getDeploymentKey("appId", "deploymentId", "deploymentKeyId").done((obj: any) => {
-            assert.ok(obj);
-            done();
-        }, rejectHandler);
-    });
-
     it("getDeploymentKeys handles JSON response", (done: MochaDone) => {
         mockReturn(JSON.stringify({ deploymentKeys: [] }), 200, {});
 
         manager.getDeploymentKeys("appId", "deploymentId").done((obj: any) => {
             assert.ok(obj);
-            done();
-        }, rejectHandler);
-    });
-
-    it("removeDeploymentKey handles success response", (done: MochaDone) => {
-        mockReturn("", 200, {});
-
-        manager.updateDeploymentKey("appId", "deploymentId", "deploymentKeyId", <any>{}).done((obj: any) => {
-            assert.ok(!obj);
-            done();
-        }, rejectHandler);
-    });
-
-    it("removeDeploymentKey handles success response", (done: MochaDone) => {
-        mockReturn("", 200, {});
-
-        manager.deleteDeploymentKey("appId", "deploymentId", "deploymentKeyId").done((obj: any) => {
-            assert.ok(!obj);
             done();
         }, rejectHandler);
     });


### PR DESCRIPTION
Trying to move us towards writing the deploymentKey directly onto the deployment object, and phasing out the /deploymentKeys REST endpoints for better perf and code clarity.