### PR TITLE
Attach label to updateCheck requests

### DIFF
--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -27,6 +27,7 @@ declare module "rest-definitions" {
         appVersion: string;
         packageHash: string;
         isCompanion: boolean;
+        label: string;
     }
 
     export interface Account {

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -83,7 +83,8 @@ export class AcquisitionManager {
             deploymentKey: this._deploymentKey,
             appVersion: currentPackage.appVersion,
             packageHash: currentPackage.packageHash,
-            isCompanion: this._ignoreAppVersion
+            isCompanion: this._ignoreAppVersion,
+            label: currentPackage.label
         };
 
         var requestUrl: string = this._serverUrl + "updateCheck?" + queryStringify(updateRequest);

--- a/sdk/test/acquisition-rest-mock.ts
+++ b/sdk/test/acquisition-rest-mock.ts
@@ -77,7 +77,8 @@ class Server {
             deploymentKey: params.deploymentKey,
             appVersion: params.appVersion,
             packageHash: params.packageHash,
-            isCompanion: !!(params.isCompanion)
+            isCompanion: !!(params.isCompanion),
+            label: params.label
         };
 
         if (!updateRequest.deploymentKey || !updateRequest.appVersion) {

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -18,7 +18,7 @@ var configuration: acquisitionSdk.Configuration = {
 var templateCurrentPackage: acquisitionSdk.Package = {
     deploymentKey: mockApi.validDeploymentKey,
     description: "sdfsdf",
-    label: "0.0.1",
+    label: "v1",
     appVersion: latestPackage.appVersion,
     packageHash: "hash001",
     isMandatory: false,


### PR DESCRIPTION
This allows the server to use the label to figure out the current version of the package instead of searching the history for the packageHash.