### PR TITLE
Remove package hashes in "deployment list" command

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -672,7 +672,6 @@ function getPackageString(packageObject: Package): string {
     return chalk.green("Label: ") + packageObject.label + "\n" +
         chalk.green("App Version: ") + packageObject.appVersion + "\n" +
         chalk.green("Mandatory: ") + (packageObject.isMandatory ? "Yes" : "No") + "\n" +
-        chalk.green("Hash: ") + packageObject.packageHash + "\n" +
         chalk.green("Release Time: ") + formatDate(packageObject.uploadTime) +
         (packageObject.description ? wordwrap(70)("\n" + chalk.green("Description: ") + packageObject.description): "");
 }


### PR DESCRIPTION
You can still see the hashes using the "--format json" flag, if needed.