### PR TITLE
CLI version bump

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push-cli",
-  "version": "1.4.0-beta",
+  "version": "1.4.1-beta",
   "description": "Management CLI for the CodePush service",
   "main": "script/cli.js",
   "scripts": {


### PR DESCRIPTION
Bumping the CLI version so we can publish the `description` regression fix to NPM.