### PR TITLE
Report Acquisition Status

### DIFF
--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -7,6 +7,14 @@ declare module "rest-definitions" {
         description?: string;
     }
 
+    export interface DeploymentStatusReport {
+        appVersion: string;
+        clientUniqueID: string;
+        deploymentKey: string; 
+        label?: string;
+        status?: string
+    }
+
     export interface PackageInfo {
         appVersion: string;
         description: string;

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -9,7 +9,7 @@ declare module "rest-definitions" {
 
     export interface DeploymentStatusReport {
         appVersion: string;
-        clientUniqueID: string;
+        clientUniqueId: string;
         deploymentKey: string; 
         label?: string;
         status?: string

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -177,7 +177,7 @@ export class AcquisitionManager {
                     return;
             }
         }
-        
+
         this._httpRequester.request(Http.Verb.POST, url, JSON.stringify(body), (error: Error, response: Http.Response): void => {
             if (callback) {
                 if (error) {

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -139,11 +139,6 @@ export class AcquisitionManager {
             callback(/*error=*/ null, remotePackage);
         });
     }
-
-    // Deprecated.
-    public reportStatus(status: string, message?: string, callback?: Callback<void>): void {
-        callback(/*error*/ null, /*not used*/ null);
-    }
     
     public reportStatusDeploy(package?: Package, status?: string, callback?: Callback<void>): void {
         var url: string = this._serverUrl + "reportStatus/deploy";

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -1,6 +1,6 @@
 /// <reference path="../definitions/harness.d.ts" />
 
-import { UpdateCheckResponse, UpdateCheckRequest } from "rest-definitions";
+import { UpdateCheckResponse, UpdateCheckRequest, DeploymentStatusReport } from "rest-definitions";
 
 export module Http {
     export const enum Verb {
@@ -51,14 +51,6 @@ export interface Configuration {
     deploymentKey: string;
     serverUrl: string;
     ignoreAppVersion?: boolean
-}
-
-interface DeploymentStatusReport {
-    appVersion: string;
-    clientUniqueID: string;
-    deploymentKey: string; 
-    label?: string;
-    status?: string
 }
 
 export class AcquisitionStatus {
@@ -148,7 +140,12 @@ export class AcquisitionManager {
         });
     }
 
-    public reportStatus(package?: Package, status?: string, callback?: Callback<void>): void {
+    // Deprecated.
+    public reportStatus(status: string, message?: string, callback?: Callback<void>): void {
+        callback(/*error*/ null, /*not used*/ null);
+    }
+    
+    public reportStatusDeploy(package?: Package, status?: string, callback?: Callback<void>): void {
         var url: string = this._serverUrl + "reportStatus/deploy";
         var body: DeploymentStatusReport = {
             appVersion: this._appVersion,
@@ -171,7 +168,7 @@ export class AcquisitionManager {
                         if (!status) {
                             callback(new Error("Missing status argument."), /*not used*/ null);
                         } else {
-                            callback(new Error("Unrecognized status" + status + "."), /*not used*/ null);
+                            callback(new Error("Unrecognized status \"" + status + "\"."), /*not used*/ null);
                         }
                     }
                     return;

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -47,7 +47,7 @@ export interface Callback<T> { (error: Error, parameter: T): void; }
 
 export interface Configuration {
     appVersion: string;
-    clientUniqueID: string;
+    clientUniqueId: string;
     deploymentKey: string;
     serverUrl: string;
     ignoreAppVersion?: boolean
@@ -60,7 +60,7 @@ export class AcquisitionStatus {
 
 export class AcquisitionManager {
     private _appVersion: string;
-    private _clientUniqueID: string;
+    private _clientUniqueId: string;
     private _deploymentKey: string;
     private _httpRequester: Http.Requester;
     private _ignoreAppVersion: boolean;
@@ -75,7 +75,7 @@ export class AcquisitionManager {
         }
 
         this._appVersion = configuration.appVersion;
-        this._clientUniqueID = configuration.clientUniqueID;
+        this._clientUniqueId = configuration.clientUniqueId;
         this._deploymentKey = configuration.deploymentKey;
         this._ignoreAppVersion = configuration.ignoreAppVersion;
     }
@@ -149,7 +149,7 @@ export class AcquisitionManager {
         var url: string = this._serverUrl + "reportStatus/deploy";
         var body: DeploymentStatusReport = {
             appVersion: this._appVersion,
-            clientUniqueID: this._clientUniqueID,
+            clientUniqueId: this._clientUniqueId,
             deploymentKey: this._deploymentKey
         };
         

--- a/sdk/script/samples/typescript-acquisition.ts
+++ b/sdk/script/samples/typescript-acquisition.ts
@@ -8,7 +8,7 @@ class MyApp {
     private _acquisition: Acquisition.NativeSample;
 
     constructor() {
-         this._acquisition = new Acquisition.NativeImplementation({ appVersion: "1.0.0", clientUniqueID: "203ff986-f335-4e94-8e79-ee404231218d", deploymentKey: "fa3s34a5s6d7f8we9a9r", serverUrl: MyApp.ServerUrl });
+         this._acquisition = new Acquisition.NativeImplementation({ appVersion: "1.0.0", clientUniqueId: "203ff986-f335-4e94-8e79-ee404231218d", deploymentKey: "fa3s34a5s6d7f8we9a9r", serverUrl: MyApp.ServerUrl });
     }
 
     public onAppStartup(): void {

--- a/sdk/script/samples/typescript-acquisition.ts
+++ b/sdk/script/samples/typescript-acquisition.ts
@@ -8,7 +8,7 @@ class MyApp {
     private _acquisition: Acquisition.NativeSample;
 
     constructor() {
-         this._acquisition = new Acquisition.NativeImplementation({ serverUrl: MyApp.ServerUrl, deploymentKey: "fa3s34a5s6d7f8we9a9r"});
+         this._acquisition = new Acquisition.NativeImplementation({ appVersion: "1.0.0", clientUniqueID: "203ff986-f335-4e94-8e79-ee404231218d", deploymentKey: "fa3s34a5s6d7f8we9a9r", serverUrl: MyApp.ServerUrl });
     }
 
     public onAppStartup(): void {

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -199,10 +199,10 @@ describe("Acquisition SDK", () => {
         done();
     });
 
-    it("reportStatus(...) signals completion", (done: MochaDone): void => {
+    it("reportStatusDeploy(...) signals completion", (done: MochaDone): void => {
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
 
-        acquisition.reportStatus(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentFailed, ((error: Error, parameter: void): void => {
+        acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentFailed, ((error: Error, parameter: void): void => {
             if (error) {
                 throw error;
             }

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -11,8 +11,10 @@ import * as rest from "rest-definitions";
 var latestPackage: rest.UpdateCheckResponse = clone(mockApi.latestPackage);
 
 var configuration: acquisitionSdk.Configuration = {
-    serverUrl: mockApi.serverUrl,
+    appVersion: "1.5.0",
+    clientUniqueID: "My iPhone",
     deploymentKey: mockApi.validDeploymentKey,
+    serverUrl: mockApi.serverUrl,
 }
 
 var templateCurrentPackage: acquisitionSdk.Package = {
@@ -200,7 +202,7 @@ describe("Acquisition SDK", () => {
     it("reportStatus(...) signals completion", (done: MochaDone): void => {
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
 
-        acquisition.reportStatus(acquisitionSdk.AcquisitionStatus.DeploymentFailed, "message", ((error: Error, parameter: void): void => {
+        acquisition.reportStatus(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentFailed, ((error: Error, parameter: void): void => {
             if (error) {
                 throw error;
             }

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -12,7 +12,7 @@ var latestPackage: rest.UpdateCheckResponse = clone(mockApi.latestPackage);
 
 var configuration: acquisitionSdk.Configuration = {
     appVersion: "1.5.0",
-    clientUniqueID: "My iPhone",
+    clientUniqueId: "My iPhone",
     deploymentKey: mockApi.validDeploymentKey,
     serverUrl: mockApi.serverUrl,
 }


### PR DESCRIPTION
Goal: To allow client devices to better report the status of their update acquisition (whether an update is successfully installed or rolled back, which update is the client running). The eventual goal is to allow developers to see this data from the CLI so that they can better manage their updates!

This PR: Mainly includes changes to the acquisition SDK
   - The config passed to the constructor for the AcquisitionManager must now include the native app version and a unique ID for the client (e.g. device GUID).
   - The reportStatus() method takes now two optional parameters - the current installed package, and the status. If both are not specified, it will be reported to the server that the app is running the version shipped with the app store binary. If both are specified, then depending on the status, it will be reported to the server that the app has either installed a new version, or that the current version has failed to install (rolled back due to an error).