### PR TITLE
reportStatusDownload

### DIFF
--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -15,6 +15,11 @@ declare module "rest-definitions" {
         status?: string
     }
 
+    export interface DownloadReport {
+        deploymentKey: string; 
+        label: string;
+    }
+
     export interface PackageInfo {
         appVersion: string;
         description: string;

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -16,6 +16,7 @@ declare module "rest-definitions" {
     }
 
     export interface DownloadReport {
+        clientUniqueId: string;
         deploymentKey: string; 
         label: string;
     }

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -190,6 +190,7 @@ export class AcquisitionManager {
     public reportStatusDownload(package: Package, callback?: Callback<void>): void {
         var url: string = this._serverUrl + "reportStatus/download";
         var body: DownloadReport = {
+            clientUniqueId: this._clientUniqueId,
             deploymentKey: this._deploymentKey,
             label: package.label
         };

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -1,6 +1,6 @@
 /// <reference path="../definitions/harness.d.ts" />
 
-import { UpdateCheckResponse, UpdateCheckRequest, DeploymentStatusReport } from "rest-definitions";
+import { UpdateCheckResponse, UpdateCheckRequest, DeploymentStatusReport, DownloadReport } from "rest-definitions";
 
 export module Http {
     export const enum Verb {
@@ -170,6 +170,30 @@ export class AcquisitionManager {
             }
         }
 
+        this._httpRequester.request(Http.Verb.POST, url, JSON.stringify(body), (error: Error, response: Http.Response): void => {
+            if (callback) {
+                if (error) {
+                    callback(error, /*not used*/ null);
+                    return;
+                }
+
+                if (response.statusCode !== 200) {
+                    callback(new Error(response.statusCode + ": " + response.body), /*not used*/ null);
+                    return;
+                }
+
+                callback(/*error*/ null, /*not used*/ null);
+            }
+        });
+    }
+    
+    public reportStatusDownload(package: Package, callback?: Callback<void>): void {
+        var url: string = this._serverUrl + "reportStatus/download";
+        var body: DownloadReport = {
+            deploymentKey: this._deploymentKey,
+            label: package.label
+        };
+        
         this._httpRequester.request(Http.Verb.POST, url, JSON.stringify(body), (error: Error, response: Http.Response): void => {
             if (callback) {
                 if (error) {

--- a/sdk/test/acquisition-rest-mock.ts
+++ b/sdk/test/acquisition-rest-mock.ts
@@ -21,6 +21,7 @@ export var latestPackage = <rest.UpdateCheckResponse>{
 
 export var serverUrl = "http://myurl.com";
 var reportStatusDeployUrl = serverUrl + "/reportStatus/deploy";
+var reportStatusDownloadUrl = serverUrl + "/reportStatus/download";
 var updateCheckUrl = serverUrl + "/updateCheck?";
 
 export class HttpRequester implements acquisitionSdk.Http.Requester {
@@ -33,6 +34,8 @@ export class HttpRequester implements acquisitionSdk.Http.Requester {
             var params = querystring.parse(url.substring(updateCheckUrl.length));
             Server.onUpdateCheck(params, callback);
         } else if (verb === acquisitionSdk.Http.Verb.POST && url === reportStatusDeployUrl) {
+            Server.onReportStatus(callback);
+        } else if (verb === acquisitionSdk.Http.Verb.POST && url === reportStatusDownloadUrl) {
             Server.onReportStatus(callback);
         } else {
             throw new Error("Unexpected call");

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -212,6 +212,20 @@ describe("Acquisition SDK", () => {
             done();
         }));
     });
+    
+    it("reportStatusDownload(...) signals completion", (done: MochaDone): void => {
+        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
+
+        acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
+            if (error) {
+                throw error;
+            }
+
+            assert.equal(parameter, /*expected*/ null);
+
+            done();
+        }));
+    });
 });
 
 function clone<T>(initialObject: T): T {


### PR DESCRIPTION
Small change. In the cordova/RN SDKs, if the install mode is ON_NEXT_RESTART, there could be a large gap of time between the time a package is downloaded and the time a package is finally installed. This adds a new acquisition API, "reportStatusDownload" to be used to report to the server whenever the client downloads a package, and will be called the moment a package is downloaded.