### PR TITLE
Remove deploymentKey method from SDK and fetch the key off the Deployment object

### DIFF
--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -33,7 +33,8 @@ export class SdkStub {
     public addDeployment(appId: string, name: string): Promise<codePush.Deployment> {
         return Q(<codePush.Deployment>{
             id: "deploymentId",
-            name: name
+            name: name,
+            key: "6"
         });
     }
 
@@ -57,23 +58,15 @@ export class SdkStub {
         }]);
     }
 
-    public getDeploymentKeys(appId: string, deploymentId: string): Promise<codePush.DeploymentKey[]> {
-        return Q([<codePush.DeploymentKey>{
-            description: null,
-            id: "5",
-            isPrimary: true,
-            key: "6",
-            name: "Primary"
-        }]);
-    }
-
     public getDeployments(appId: string): Promise<codePush.Deployment[]> {
         return Q([<codePush.Deployment>{
             id: "3",
-            name: "Production"
+            name: "Production",
+            key: "6"
         }, <codePush.Deployment>{
             id: "4",
             name: "Staging",
+            key: "6",
             package: {
                 appVersion: "1.0.0",
                 description: "fgh",
@@ -350,12 +343,10 @@ describe("CLI", () => {
         };
 
         var addDeployment: Sinon.SinonSpy = sandbox.spy(cmdexec.sdk, "addDeployment");
-        var getDeploymentKeys: Sinon.SinonSpy = sandbox.spy(cmdexec.sdk, "getDeploymentKeys");
 
         cmdexec.execute(command)
             .done((): void => {
                 sinon.assert.calledOnce(addDeployment);
-                sinon.assert.calledOnce(getDeploymentKeys);
                 sinon.assert.calledOnce(log);
                 sinon.assert.calledWithExactly(log, "Successfully added the \"b\" deployment with key \"6\" to the \"a\" app.");
                 done();
@@ -378,11 +369,11 @@ describe("CLI", () => {
                 var expected = [
                     {
                         name: "Production",
-                        deploymentKey: "6"
+                        key: "6"
                     },
                     {
                         name: "Staging",
-                        deploymentKey: "6",
+                        key: "6",
                         package: {
                             appVersion: "1.0.0",
                             description: "fgh",

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -10,14 +10,14 @@ declare module "rest-definitions" {
     export interface DeploymentStatusReport {
         appVersion: string;
         clientUniqueId: string;
-        deploymentKey: string; 
+        deploymentKey: string;
         label?: string;
         status?: string
     }
 
     export interface DownloadReport {
         clientUniqueId: string;
-        deploymentKey: string; 
+        deploymentKey: string;
         label: string;
     }
 
@@ -59,15 +59,8 @@ declare module "rest-definitions" {
     export interface Deployment {
         /*generated*/ id?: string;
         name: string;
+        /*generated*/ key?: string;
         package?: Package
-    }
-
-    export interface DeploymentKey {
-        description: string;
-        /*generated*/ id?: string;
-        isPrimary: boolean;
-        /*generated*/ key: string;
-        name: string;
     }
 
     export interface Package extends PackageInfo {

--- a/sdk/script/account-manager.ts
+++ b/sdk/script/account-manager.ts
@@ -19,8 +19,8 @@ if (typeof window === "undefined") {
     }
 }
 
-import { AccessKey, Account, App, Deployment, DeploymentKey, Package } from "rest-definitions";
-export { AccessKey, Account, App, Deployment, DeploymentKey, Package };
+import { AccessKey, Account, App, Deployment, Package } from "rest-definitions";
+export { AccessKey, Account, App, Deployment, Package };
 
 export interface CodePushError {
     message?: string;
@@ -414,16 +414,14 @@ export class AccountManager {
                         return;
                     }
 
+                    var body = tryJSON(res.text);
                     if (res.ok) {
-                        var location = res.header["location"];
-                        if (location && location.lastIndexOf("/") !== -1) {
-                            deployment.id = location.substr(location.lastIndexOf("/") + 1);
-                            resolve(deployment);
+                        if (body) {
+                            resolve(body.deployment);
                         } else {
-                            resolve(null);
+                            reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
                         }
                     } else {
-                        var body = tryJSON(res.text);
                         if (body) {
                             reject(<CodePushError>body);
                         } else {
@@ -535,35 +533,6 @@ export class AccountManager {
                     resolve(null);
                 } else {
                     var body = tryJSON(res.text);
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
-    }
-
-    public getDeploymentKeys(appId: string, deploymentId: string): Promise<DeploymentKey[]> {
-        return Promise<DeploymentKey[]>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/deploymentKeys")
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                var body = tryJSON(res.text);
-                if (res.ok) {
-                    if (body) {
-                        resolve(body.deploymentKeys);
-                    } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                    }
-                } else {
                     if (body) {
                         reject(<CodePushError>body);
                     } else {

--- a/sdk/test/management-sdk.ts
+++ b/sdk/test/management-sdk.ts
@@ -34,8 +34,6 @@ describe("Management SDK", () => {
             manager.updateDeployment.bind(manager, "appId", { id: "deploymentToChange" }),
             manager.removeDeployment.bind(manager, "appId", { id: "deploymentToChange" }),
 
-            manager.getDeploymentKeys.bind(manager, "appId", "deploymentId"),
-
             manager.getPackage.bind(manager, ""),
         ];
 
@@ -135,19 +133,10 @@ describe("Management SDK", () => {
     });
 
     it("addDeployment handles success response", (done: MochaDone) => {
-        mockReturn("", 200, { location: "/deploymentId" });
+        mockReturn(JSON.stringify({ deployment: { name: "name", key: "key" } }), 201, { location: "/deploymentId" });
 
         manager.addDeployment("appId", "name").done((obj: any) => {
             assert.ok(obj);
-            done();
-        }, rejectHandler);
-    });
-
-    it("addDeployment handles missing location header", (done: MochaDone) => {
-        mockReturn("", 200, {});
-
-        manager.addDeployment("appId", "name").done((obj: any) => {
-            assert.ok(!obj);
             done();
         }, rejectHandler);
     });
@@ -184,15 +173,6 @@ describe("Management SDK", () => {
 
         manager.removeDeployment("appId", "deploymentId").done((obj: any) => {
             assert.ok(!obj);
-            done();
-        }, rejectHandler);
-    });
-
-    it("getDeploymentKeys handles JSON response", (done: MochaDone) => {
-        mockReturn(JSON.stringify({ deploymentKeys: [] }), 200, {});
-
-        manager.getDeploymentKeys("appId", "deploymentId").done((obj: any) => {
-            assert.ok(obj);
             done();
         }, rejectHandler);
     });


### PR DESCRIPTION
(merging into 'breaking' branch)

This mirrors an upcoming breaking change on the server. This little tweak simplifies our code base and gives us a modest perf improvement.