### PR TITLE
Renaming some of the release parameters

### DIFF
--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -169,10 +169,10 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         addCommonConfiguration(yargs);
     })
     .command("release", "Release a new version of your app to a specific deployment", (yargs: yargs.Argv) => {
-        yargs.usage(USAGE_PREFIX + " release <appName> <package> <appStoreVersion> [--deploymentName <deploymentName>] [--description <description>] [--mandatory]")
+        yargs.usage(USAGE_PREFIX + " release <appName> <updateContentsPath> <targetBinaryVersion> [--deploymentName <deploymentName>] [--description <description>] [--mandatory]")
             .demand(/*count*/ 4, /*max*/ 4)  // Require exactly four non-option arguments.
-            .example("release MyApp app.js 1.0.3", "Upload app.js to the default deployment for app \"MyApp\" with the required semver compliant app store version of 1.0.3")
-            .example("release MyApp ./platforms/ios/www 1.0.3 -d Production", "Upload the \"./platforms/ios/www\" folder and all its contents to the \"Production\" deployment for app \"MyApp\" with the required semver compliant app store version of 1.0.3")
+            .example("release MyApp app.js 1.0.3", "Release the \"app.js\" file to the \"MyApp\" app's staging deployment, targeting the 1.0.3 binary version")
+            .example("release MyApp ./platforms/ios/www 1.0.3 -d Production", "Release the \"./platforms/ios/www\" folder and all its contents to the \"MyApp\" app's \"Production\" deployment, targetting the 1.0.3 binary version")
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "The deployment to publish the update to", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" });

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -190,7 +190,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         yargs.usage(USAGE_PREFIX + " rollback <appName> <deploymentName> [--targetRelease <releaseLabel>]")
             .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
             .example("rollback MyApp Production", "Perform a rollback on the \"Production\" deployment of \"MyApp\"")
-            .example("rollback MyApp Production --targetRelease v4", "Perform a rollback on the \"Production\" deployment of \"MyApp\" to the v4 release.")
+            .example("rollback MyApp Production --targetRelease v4", "Perform a rollback on the \"Production\" deployment of \"MyApp\" to the v4 release")
             .option("targetRelease", { alias: "r", default: null, demand: false, description: "The label of the release to be rolled back to (e.g. v4)", type: "string" });
 
         addCommonConfiguration(yargs);
@@ -242,8 +242,8 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         isValidCommand = true;
         yargs.usage(USAGE_PREFIX + " logout [--local]")
             .demand(/*count*/ 1, /*max*/ 1)  // Require exactly one non-option argument.
-            .example("logout", "Log out and also remove the access key used for the current session.")
-            .example("logout --local", "Log out but allow the use of the same access key for future logins.")
+            .example("logout", "Log out and also remove the access key used for the current session")
+            .example("logout --local", "Log out but allow the use of the same access key for future logins")
             .option("local", { demand: false, description: "Whether to delete the current session's access key on the server", type: "boolean" });
         addCommonConfiguration(yargs);
     })

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -172,7 +172,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         yargs.usage(USAGE_PREFIX + " release <appName> <updateContentsPath> <targetBinaryVersion> [--deploymentName <deploymentName>] [--description <description>] [--mandatory]")
             .demand(/*count*/ 4, /*max*/ 4)  // Require exactly four non-option arguments.
             .example("release MyApp app.js 1.0.3", "Release the \"app.js\" file to the \"MyApp\" app's staging deployment, targeting the 1.0.3 binary version")
-            .example("release MyApp ./platforms/ios/www 1.0.3 -d Production", "Release the \"./platforms/ios/www\" folder and all its contents to the \"MyApp\" app's \"Production\" deployment, targetting the 1.0.3 binary version")
+            .example("release MyApp ./platforms/ios/www 1.0.3 -d Production", "Release the \"./platforms/ios/www\" folder and all its contents to the \"MyApp\" app's \"Production\" deployment, targeting the 1.0.3 binary version")
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "The deployment to publish the update to", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" });


### PR DESCRIPTION
Updating the names and examples for the `release` command to be a little more intuitive.