### PR TITLE
Removing try-json dependency

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -38,7 +38,6 @@
     "recursive-fs": "0.1.4",
     "semver": "4.3.6",
     "slash": "1.0.0",
-    "try-json": "^1.0.0",
     "update-notifier": "^0.5.0",
     "wordwrap": "1.0.0",
     "yargs": "^3.15.0",


### PR DESCRIPTION
This simply removes the CLI's dependency on the `try-json` library, which addresses the warning users see when installing the CLI (as reported by #96).