### PR TITLE
Renaming 'package' parameters

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "1.5.0-beta",
+  "version": "1.5.1-beta",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/plugin.xml
+++ b/sdk/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="code-push" version="1.5.0-beta">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="code-push" version="1.5.1-beta">
 	<name>CodePushAcquisition</name>
 	<description>CodePush Acquisition Plugin for Apache Cordova</description>
 	<license>MIT</license>

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -140,7 +140,7 @@ export class AcquisitionManager {
         });
     }
     
-    public reportStatusDeploy(package?: Package, status?: string, callback?: Callback<void>): void {
+    public reportStatusDeploy(deployedPackage?: Package, status?: string, callback?: Callback<void>): void {
         var url: string = this._serverUrl + "reportStatus/deploy";
         var body: DeploymentStatusReport = {
             appVersion: this._appVersion,
@@ -148,9 +148,9 @@ export class AcquisitionManager {
             deploymentKey: this._deploymentKey
         };
         
-        if (package) {
-            body.label = package.label;
-            body.appVersion = package.appVersion;
+        if (deployedPackage) {
+            body.label = deployedPackage.label;
+            body.appVersion = deployedPackage.appVersion;
             
             switch (status) {
                 case AcquisitionStatus.DeploymentSucceeded:
@@ -187,12 +187,12 @@ export class AcquisitionManager {
         });
     }
     
-    public reportStatusDownload(package: Package, callback?: Callback<void>): void {
+    public reportStatusDownload(downloadedPackage: Package, callback?: Callback<void>): void {
         var url: string = this._serverUrl + "reportStatus/download";
         var body: DownloadReport = {
             clientUniqueId: this._clientUniqueId,
             deploymentKey: this._deploymentKey,
-            label: package.label
+            label: downloadedPackage.label
         };
         
         this._httpRequester.request(Http.Verb.POST, url, JSON.stringify(body), (error: Error, response: Http.Response): void => {


### PR DESCRIPTION
Replacing uses of the identifier `package` since that is a reserved keyword, which Babel will reject when bundling this file as part of a React Native app. I'm also bumping the version so that we can release this update to NPM.