### PR TITLE
Display acquisition metrics

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -799,8 +799,8 @@ function getPackageMetricsString(packageObject: PackageWithMetrics, showInstalls
         if (numPending > 0) {
             returnString += " (" + numPending.toLocaleString() + " pending)";
         }
-    } else if (numPending > 0) {
-        returnString += "Pending: " +  numPending.toLocaleString();
+    } else {
+        returnString += "Pending: " + Math.max(numPending, 0).toLocaleString();
     }
     
     if (packageObject.metrics.failed) {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -719,7 +719,7 @@ function printDeploymentList(command: cli.IDeploymentListCommand, deployments: D
                 
                 if (showPackage) {
                     row.push(getPackageString(deployment.package));
-                    row.push(getPackageMetricsString(<PackageWithMetrics>(deployment.package)));
+                    row.push(getPackageMetricsString(<PackageWithMetrics>(deployment.package), /* showInstalls */ false));
                 }
                 
                 dataSource.push(row);
@@ -779,7 +779,7 @@ function getPackageString(packageObject: Package): string {
         (packageObject.description ? wordwrap(70)("\n" + chalk.green("Description: ") + packageObject.description): "");
 }
 
-function getPackageMetricsString(packageObject: PackageWithMetrics): string {
+function getPackageMetricsString(packageObject: PackageWithMetrics, showInstalls: boolean = true): string {
     if (!packageObject || !packageObject.metrics) {
         return "";
     }
@@ -787,14 +787,19 @@ function getPackageMetricsString(packageObject: PackageWithMetrics): string {
     var activePercent: number = packageObject.metrics.totalActive
         ? packageObject.metrics.active / packageObject.metrics.totalActive * 100
         : 0.0;
-    var percentString: string = (activePercent === 100.0 ? "100" : activePercent.toPrecision(2)) + "%";
-    var numPending: number = packageObject.metrics.downloaded - packageObject.metrics.installed - packageObject.metrics.failed;
-    var returnString: string = chalk.green("Active: ") + percentString + " (" + packageObject.metrics.active.toLocaleString() + " of " + packageObject.metrics.totalActive.toLocaleString() + ")\n" +
-        chalk.green("Installs: ") + packageObject.metrics.installed.toLocaleString();
         
-    if (numPending) {
-        returnString += " (" + numPending.toLocaleString() + " pending)";
-    }    
+    var percentString: string = (activePercent === 100.0 ? "100" : activePercent.toPrecision(2)) + "%";
+    
+    var numPending: number = packageObject.metrics.downloaded - packageObject.metrics.installed - packageObject.metrics.failed;
+    var returnString: string = chalk.green("Active: ") + percentString + " (" + packageObject.metrics.active.toLocaleString() + " of " + packageObject.metrics.totalActive.toLocaleString() + ")";
+    if (showInstalls){
+        returnString += "\n" + chalk.green("Installs: ") + packageObject.metrics.installed.toLocaleString();
+        if (numPending > 0) {
+            returnString += " (" + numPending.toLocaleString() + " pending)";
+        }
+    } else if (numPending > 0) {
+        returnString += "Pending: " +  numPending.toLocaleString();
+    }
     
     if (packageObject.metrics.failed) {
         returnString += "\n" + chalk.green("Rollbacks: ") + chalk.red(packageObject.metrics.failed.toLocaleString() + "");

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -800,7 +800,7 @@ function getPackageMetricsString(packageObject: PackageWithMetrics, showInstalls
             returnString += " (" + numPending.toLocaleString() + " pending)";
         }
     } else {
-        returnString += "Pending: " + Math.max(numPending, 0).toLocaleString();
+        returnString += "\nPending: " + Math.max(numPending, 0).toLocaleString();
     }
     
     if (packageObject.metrics.failed) {


### PR DESCRIPTION
For the "deployment ls" command, we will show the "Pending" key instead of the "Installed" key by default, since the number of Installed versions for the latest package should be equal to the number of "Active" versions.

Also, if there are no active users, make an exception to show "0%" instead of "0.0%".