### PR TITLE
Adding no updates message

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -764,7 +764,7 @@ function printDeploymentHistory(command: cli.IDeploymentHistoryCommand, packageH
 
 function getPackageString(packageObject: Package): string {
     if (!packageObject) {
-        return "";
+        return chalk.magenta("No updates released").toString();
     }
 
     return chalk.green("Label: ") + packageObject.label + "\n" +


### PR DESCRIPTION
This PR simply adds a new message to the `Update Metadata` column in the table output by `deployment ls` for deployments that haven't had an update released to them yet. It is consistent with the message that we display in the new `Install Metrics` column when a specific deployment/release hasn't had any install reports yet.