### PR TITLE
Metrics SDK Changes

### DIFF
--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -15,8 +15,8 @@ declare module "rest-definitions" {
         appVersion: string;
         clientUniqueId?: string;
         deploymentKey: string;
-        fromDeploymentKey?: string;
-        fromLabelOrAppVersion?: string;
+        previousDeploymentKey?: string;
+        previousLabelOrAppVersion?: string;
         label?: string;
         status?: string;
     }

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -13,10 +13,12 @@ declare module "rest-definitions" {
 
     export interface DeploymentStatusReport {
         appVersion: string;
-        clientUniqueId: string;
-        deploymentKey: string; 
+        clientUniqueId?: string;
+        deploymentKey: string;
+        fromDeploymentKey?: string;
+        fromLabelOrAppVersion?: string;
         label?: string;
-        status?: string
+        status?: string;
     }
     
     export interface DownloadReport {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "1.5.1-beta",
+  "version": "1.5.2-beta",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -140,7 +140,7 @@ export class AcquisitionManager {
         });
     }
     
-    public reportStatusDeploy(deployedPackage?: Package, status?: string, fromLabelOrAppVersion?: string, fromDeploymentKey?: string, callback?: Callback<void>): void {
+    public reportStatusDeploy(deployedPackage?: Package, status?: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string, callback?: Callback<void>): void {
         var url: string = this._serverUrl + "reportStatus/deploy";
         var body: DeploymentStatusReport = {
             appVersion: this._appVersion,
@@ -173,12 +173,12 @@ export class AcquisitionManager {
             }
         }
         
-        if (fromLabelOrAppVersion) {
-            body.fromLabelOrAppVersion = fromLabelOrAppVersion;
+        if (previousLabelOrAppVersion) {
+            body.previousLabelOrAppVersion = previousLabelOrAppVersion;
         }
         
-        if (fromDeploymentKey) {
-            body.fromDeploymentKey = fromDeploymentKey;
+        if (previousDeploymentKey) {
+            body.previousDeploymentKey = previousDeploymentKey;
         }
         
         callback = typeof arguments[arguments.length - 1] === "function" && arguments[arguments.length - 1];

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -140,13 +140,16 @@ export class AcquisitionManager {
         });
     }
     
-    public reportStatusDeploy(deployedPackage?: Package, status?: string, callback?: Callback<void>): void {
+    public reportStatusDeploy(deployedPackage?: Package, status?: string, fromLabelOrAppVersion?: string, fromDeploymentKey?: string, callback?: Callback<void>): void {
         var url: string = this._serverUrl + "reportStatus/deploy";
         var body: DeploymentStatusReport = {
             appVersion: this._appVersion,
-            clientUniqueId: this._clientUniqueId,
             deploymentKey: this._deploymentKey
         };
+        
+        if (this._clientUniqueId) {
+            body.clientUniqueId = this._clientUniqueId;
+        }
         
         if (deployedPackage) {
             body.label = deployedPackage.label;
@@ -169,7 +172,17 @@ export class AcquisitionManager {
                     return;
             }
         }
-
+        
+        if (fromLabelOrAppVersion) {
+            body.fromLabelOrAppVersion = fromLabelOrAppVersion;
+        }
+        
+        if (fromDeploymentKey) {
+            body.fromDeploymentKey = fromDeploymentKey;
+        }
+        
+        callback = typeof arguments[arguments.length - 1] === "function" && arguments[arguments.length - 1];
+        
         this._httpRequester.request(Http.Verb.POST, url, JSON.stringify(body), (error: Error, response: Http.Response): void => {
             if (callback) {
                 if (error) {

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -202,7 +202,7 @@ describe("Acquisition SDK", () => {
     it("reportStatusDeploy(...) signals completion", (done: MochaDone): void => {
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
 
-        acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentFailed, ((error: Error, parameter: void): void => {
+        acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentFailed, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
             if (error) {
                 throw error;
             }


### PR DESCRIPTION
Change the Acquisition SDK to allow clients to send previous version deployment key and label as part of the client state.