### PR TITLE
Tidy up SDK

### DIFF
--- a/definitions/try-json.d.ts
+++ b/definitions/try-json.d.ts
@@ -1,5 +1,0 @@
-declare module "try-json" {
-    function tryJSON(value: any): any;
-
-    export = tryJSON;
-}

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -18,7 +18,6 @@
     "fs": "0.0.2",
     "node-uuid": "^1.4.3",
     "q": "^1.4.1",
-    "superagent": "git://github.com/visionmedia/superagent.git#45a1290b2fe5a56a1d77ca74e0b236178d58d848",
-    "try-json": "^1.0.0"
+    "superagent": "git://github.com/visionmedia/superagent.git#45a1290b2fe5a56a1d77ca74e0b236178d58d848"
   }
 }

--- a/sdk/script/account-manager.ts
+++ b/sdk/script/account-manager.ts
@@ -59,7 +59,7 @@ export class AccountManager {
 
     public isAuthenticated(): Promise<boolean> {
         return Promise<boolean>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + `/authenticated`);
+            var request: superagent.Request<any> = superagent.get(`${this._serverUrl}/authenticated`);
             this.attachCredentials(request);
 
             request.end((err: any, res: superagent.Response) => {
@@ -82,7 +82,7 @@ export class AccountManager {
                 var accessKey: AccessKey = { id: null, name: newAccessKey, createdTime: new Date().getTime(), createdBy: machine, description: description };
                 return this.post(`/accessKeys/`, JSON.stringify(accessKey), /*expectResponseBody=*/ false)
                     .then((res: JsonResponse) => {
-                        var location = res.header[`location`];
+                        var location: string = res.header[`location`];
                         if (location && location.lastIndexOf(`/`) !== -1) {
                             accessKey.id = location.substr(location.lastIndexOf(`/`) + 1);
                             return accessKey;
@@ -131,7 +131,7 @@ export class AccountManager {
     }
 
     public addApp(appName: string): Promise<App> {
-        var app = <App>{ name: appName };
+        var app: App = { name: appName };
         return this.post(`/apps/`, JSON.stringify(app), /*expectResponseBody=*/ false)
             .then((res: JsonResponse) => {
                 var location = res.header[`location`];
@@ -145,7 +145,7 @@ export class AccountManager {
     }
 
     public removeApp(app: App | string): Promise<void> {
-        var id: string = (typeof app === `string`) ? (<string><any>app) : (<App><any>app).id;
+        var id: string = (typeof app === `string`) ? (<string>app) : (<App>app).id;
         return this.del(`/apps/${id}`)
             .then(() => null);
     }
@@ -183,7 +183,7 @@ export class AccountManager {
     }
 
     public removeDeployment(appId: string, deployment: Deployment | string): Promise<void> {
-        var id: string = (typeof deployment === `string`) ? (<string><any>deployment) : (<Deployment><any>deployment).id;
+        var id: string = (typeof deployment === `string`) ? (<string>deployment) : (<Deployment>deployment).id;
         return this.del(`/apps/${appId}/deployments/${id}`)
             .then(() => null);
     }

--- a/sdk/script/account-manager.ts
+++ b/sdk/script/account-manager.ts
@@ -9,12 +9,12 @@ var packageJson = require("../../package.json");
 
 declare var fs: any;
 
-if (typeof window === "undefined") {
-    fs = require("fs");
+if (typeof window === `undefined`) {
+    fs = require(`fs`);
 } else {
     fs = {
         createReadStream: (fileOrPath: string): void => {
-            throw new Error("Tried to call a node fs function from the browser.");
+            throw new Error(`Tried to call a node fs function from the browser.`);
         }
     }
 }
@@ -36,8 +36,13 @@ interface PackageToUpload {
     isMandatory: boolean;
 }
 
+interface JsonResponse {
+    header: { [headerName: string]: string };
+    body?: any;
+}
+
 export class AccountManager {
-    private static API_VERSION = "v2";
+    private static API_VERSION = `v2`;
 
     private _accessKey: string;
     private _serverUrl: string;
@@ -45,8 +50,8 @@ export class AccountManager {
 
     constructor(accessKey: string, userAgent?: string, serverUrl?: string) {
         this._accessKey = accessKey;
-        this._userAgent = userAgent || (packageJson.name + "/" + packageJson.version);
-        this._serverUrl = serverUrl || "https://codepush.azurewebsites.net";
+        this._userAgent = userAgent || (`${packageJson.name}/${packageJson.version}`);
+        this._serverUrl = serverUrl || `https://codepush.azurewebsites.net`;
     }
 
     public get accessKey(): string {
@@ -55,7 +60,7 @@ export class AccountManager {
 
     public isAuthenticated(): Promise<boolean> {
         return Promise<boolean>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/authenticated");
+            var request: superagent.Request<any> = superagent.get(this._serverUrl + `/authenticated`);
             this.attachCredentials(request);
 
             request.end((err: any, res: superagent.Response) => {
@@ -73,523 +78,133 @@ export class AccountManager {
     }
 
     public addAccessKey(machine: string, description?: string): Promise<AccessKey> {
-        return Promise<AccessKey>((resolve, reject, notify) => {
-            return this.generateAccessKey().then((newAccessKey: string) => {
+        return this.generateAccessKey()
+            .then((newAccessKey: string) => {
                 var accessKey: AccessKey = { id: null, name: newAccessKey, createdTime: new Date().getTime(), createdBy: machine, description: description };
-                var request: superagent.Request<any> = superagent.post(this._serverUrl + "/accessKeys/");
-
-                this.attachCredentials(request);
-
-                request.set("Content-Type", "application/json;charset=UTF-8")
-                    .send(JSON.stringify(accessKey))
-                    .end((err: any, res: superagent.Response) => {
-                        if (err) {
-                            reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                            return;
-                        }
-
-                        if (res.ok) {
-                            var location = res.header["location"];
-                            if (location && location.lastIndexOf("/") !== -1) {
-                                accessKey.id = location.substr(location.lastIndexOf("/") + 1);
-                                resolve(accessKey);
-                            } else {
-                                resolve(null);
-                            }
+                return this.post(`/accessKeys/`, JSON.stringify(accessKey), /*expectResponseBody=*/ false)
+                    .then((res: JsonResponse) => {
+                        var location = res.header[`location`];
+                        if (location && location.lastIndexOf(`/`) !== -1) {
+                            accessKey.id = location.substr(location.lastIndexOf(`/`) + 1);
+                            return accessKey;
                         } else {
-                            var body = tryJSON(res.text);
-                            if (body) {
-                                reject(<CodePushError>body);
-                            } else {
-                                reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                            }
+                            return null;
                         }
                     });
             });
-        });
     }
 
     public getAccessKey(accessKeyId: string): Promise<AccessKey> {
-        return Promise<AccessKey>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/accessKeys/" + accessKeyId);
-
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                var body = tryJSON(res.text);
-                if (res.ok) {
-                    if (body) {
-                        resolve(body.accessKey);
-                    } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                    }
-                } else {
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.get(`/accessKeys/${accessKeyId}`)
+            .then((res: JsonResponse) => res.body.accessKey);
     }
 
     public getAccessKeys(): Promise<AccessKey[]> {
-        return Promise<AccessKey[]>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/accessKeys");
-
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                var body = tryJSON(res.text);
-                if (res.ok) {
-                    if (body) {
-                        resolve(body.accessKeys);
-                    } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                    }
-                } else {
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.get(`/accessKeys`)
+            .then((res: JsonResponse) => res.body.accessKeys);
     }
 
     public removeAccessKey(accessKeyId: string): Promise<void> {
-        return Promise<void>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.del(this._serverUrl + "/accessKeys/" + accessKeyId);
-
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                if (res.ok) {
-                    resolve(null);
-                } else {
-                    var body = tryJSON(res.text);
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.del(`/accessKeys/${accessKeyId}`)
+            .then(() => null);
     }
 
     // Account
     public getAccountInfo(): Promise<Account> {
-        return Promise<Account>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/account");
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                var body = tryJSON(res.text);
-
-                if (res.ok) {
-                    if (body) {
-                        resolve(body.account);
-                    } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                    }
-                } else {
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.get(`/account`)
+            .then((res: JsonResponse) => res.body.account);
     }
 
     public updateAccountInfo(accountInfoToChange: Account): Promise<void> {
-        return Promise<void>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.put(this._serverUrl + "/account");
-            this.attachCredentials(request);
-
-            request.set("Content-Type", "application/json;charset=UTF-8")
-                .send(JSON.stringify(accountInfoToChange))
-                .end((err: any, res: superagent.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
-
-                    if (res.ok) {
-                        resolve(null);
-                    } else {
-                        var body = tryJSON(res.text);
-                        if (body) {
-                            reject(<CodePushError>body);
-                        } else {
-                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                        }
-                    }
-                });
-        });
+        return this.put(`/account`, JSON.stringify(accountInfoToChange))
+            .then(() => null);
     }
 
     // Apps
     public getApps(): Promise<App[]> {
-        return Promise<App[]>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/apps");
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                var body = tryJSON(res.text);
-                if (res.ok) {
-                    if (body) {
-                        resolve(body.apps);
-                    } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                    }
-                } else {
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.get(`/apps`)
+            .then((res: JsonResponse) => res.body.apps);
     }
 
     public getApp(appId: string): Promise<App> {
-        return Promise<App>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/apps/" + appId);
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                var body = tryJSON(res.text);
-                if (res.ok) {
-                    if (body) {
-                        resolve(body.app);
-                    } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                    }
-                } else {
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.get(`/apps/${appId}`)
+            .then((res: JsonResponse) => res.body.app);
     }
 
     public addApp(appName: string): Promise<App> {
-        return Promise<App>((resolve, reject, notify) => {
-            var app = <App>{ name: appName };
-
-            var request: superagent.Request<any> = superagent.post(this._serverUrl + "/apps/");
-            this.attachCredentials(request);
-
-            request.set("Content-Type", "application/json;charset=UTF-8")
-                .send(JSON.stringify(app))
-                .end((err: any, res: superagent.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
-
-                    if (res.ok) {
-                        var location = res.header["location"];
-                        if (location && location.lastIndexOf("/") !== -1) {
-                            app.id = location.substr(location.lastIndexOf("/") + 1);
-                            resolve(app);
-                        } else {
-                            resolve(null);
-                        }
-                    } else {
-                        var body = tryJSON(res.text);
-                        if (body) {
-                            reject(<CodePushError>body);
-                        } else {
-                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                        }
-                    }
-                });
-        });
+        var app = <App>{ name: appName };
+        return this.post(`/apps/`, JSON.stringify(app), /*expectResponseBody=*/ false)
+            .then((res: JsonResponse) => {
+                var location = res.header[`location`];
+                if (location && location.lastIndexOf(`/`) !== -1) {
+                    app.id = location.substr(location.lastIndexOf(`/`) + 1);
+                    return app;
+                } else {
+                    return null;
+                }
+            });
     }
 
     public removeApp(app: App | string): Promise<void> {
-        return Promise<void>((resolve, reject, notify) => {
-            var id: string = (typeof app === "string") ? app : app.id;
-            var request: superagent.Request<any> = superagent.del(this._serverUrl + "/apps/" + id);
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                if (res.ok) {
-                    resolve(null);
-                } else {
-                    var body = tryJSON(res.text);
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        var id: string = (typeof app === `string`) ? (<string><any>app) : (<App><any>app).id;
+        return this.del(`/apps/${id}`)
+            .then(() => null);
     }
 
     public updateApp(infoToChange: App): Promise<void> {
-        return Promise<void>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.put(this._serverUrl + "/apps/" + infoToChange.id);
-            this.attachCredentials(request);
-
-            request.set("Content-Type", "application/json;charset=UTF-8")
-                .send(JSON.stringify(infoToChange))
-                .end((err: any, res: superagent.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
-
-                    if (res.ok) {
-                        resolve(null);
-                    } else {
-                        var body = tryJSON(res.text);
-                        if (body) {
-                            reject(<CodePushError>body);
-                        } else {
-                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                        }
-                    }
-                });
-        });
+        return this.put(`/apps/${infoToChange.id}`, JSON.stringify(infoToChange))
+            .then((res: JsonResponse) => null);
     }
 
     // Deployments
     public addDeployment(appId: string, name: string): Promise<Deployment> {
-        return Promise<Deployment>((resolve, reject, notify) => {
-            var deployment = <Deployment>{ name: name };
-
-            var request: superagent.Request<any> = superagent.post(this._serverUrl + "/apps/" + appId + "/deployments/");;
-            this.attachCredentials(request);
-
-            request.set("Content-Type", "application/json;charset=UTF-8")
-                .send(JSON.stringify(deployment))
-                .end((err: any, res: superagent.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
-
-                    var body = tryJSON(res.text);
-                    if (res.ok) {
-                        if (body) {
-                            resolve(body.deployment);
-                        } else {
-                            reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                        }
-                    } else {
-                        if (body) {
-                            reject(<CodePushError>body);
-                        } else {
-                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                        }
-                    }
-                });
-        });
+        var deployment = <Deployment>{ name: name };
+        return this.post(`/apps/${appId}/deployments/`, JSON.stringify(deployment), /*expectResponseBody=*/ true)
+            .then((res: JsonResponse) => res.body.deployment);
     }
 
     public getDeployments(appId: string): Promise<Deployment[]> {
-        return Promise<Deployment[]>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/apps/" + appId + "/deployments");
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                var body = tryJSON(res.text);
-                if (res.ok) {
-                    if (body) {
-                        resolve(body.deployments);
-                    } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                    }
-                } else {
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.get(`/apps/${appId}/deployments/`)
+            .then((res: JsonResponse) => res.body.deployments);
     }
 
     public getDeployment(appId: string, deploymentId: string): Promise<Deployment> {
-        return Promise<Deployment>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/apps/" + appId + "/deployments/" + deploymentId);
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                var body = tryJSON(res.text);
-                if (res.ok) {
-                    if (body) {
-                        resolve(body.deployment);
-                    } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                    }
-                } else {
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.get(`/apps/${appId}/deployments/${deploymentId}`)
+            .then((res: JsonResponse) => res.body.deployment);
     }
 
     public getDeploymentMetrics(appId: string, deploymentId: string): Promise<DeploymentMetrics> {
-        return Promise<DeploymentMetrics>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/metrics");
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                var body = tryJSON(res.text);
-                if (res.ok) {
-                    if (body) {
-                        resolve(body.metrics);
-                    } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                    }
-                } else {
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.get(`/apps/${appId}/deployments/${deploymentId}/metrics`)
+            .then((res: JsonResponse) => res.body.metrics);
     }
 
     public updateDeployment(appId: string, infoToChange: Deployment): Promise<void> {
-        return Promise<void>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.put(this._serverUrl + "/apps/" + appId + "/deployments/" + infoToChange.id);
-            this.attachCredentials(request);
-
-            request.set("Content-Type", "application/json;charset=UTF-8")
-                .send(JSON.stringify(infoToChange))
-                .end((err: any, res: superagent.Response) => {
-                    if (err) {
-                        reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                        return;
-                    }
-
-                    if (res.ok) {
-                        resolve(null);
-                    } else {
-                        var body = tryJSON(res.text);
-                        if (body) {
-                            reject(<CodePushError>body);
-                        } else {
-                            reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                        }
-                    }
-                });
-        });
+        return this.put(`/apps/${appId}/deployments/${infoToChange.id}`, JSON.stringify(infoToChange))
+            .then(() => null);
     }
 
     public removeDeployment(appId: string, deployment: Deployment | string): Promise<void> {
-        return Promise<void>((resolve, reject, notify) => {
-            var id: string = (typeof deployment === "string") ? deployment : deployment.id;
-            var request: superagent.Request<any> = superagent.del(this._serverUrl + "/apps/" + appId + "/deployments/" + id);
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                if (res.ok) {
-                    resolve(null);
-                } else {
-                    var body = tryJSON(res.text);
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        var id: string = (typeof deployment === `string`) ? (<string><any>deployment) : (<Deployment><any>deployment).id;
+        return this.del(`/apps/${appId}/deployments/${id}`)
+            .then(() => null);
     }
 
     public addPackage(appId: string, deploymentId: string, fileOrPath: File | string, description: string, label: string, appVersion: string, isMandatory: boolean = false, uploadProgressCallback?: (progress: number) => void): Promise<void> {
         return Promise<void>((resolve, reject, notify) => {
             var packageInfo: PackageToUpload = this.generatePackageInfo(description, label, appVersion, isMandatory);
-            var request: superagent.Request<any> = superagent.put(this._serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/package");
+            var request: superagent.Request<any> = superagent.put(`${this._serverUrl}/apps/${appId}/deployments/${deploymentId}/package`);
             this.attachCredentials(request);
 
             var file: any;
-            if (typeof fileOrPath === "string") {
+            if (typeof fileOrPath === `string`) {
                 file = fs.createReadStream(<string>fileOrPath);
             } else {
                 file = fileOrPath;
             }
 
-            request.attach("package", file)
-                .field("packageInfo", JSON.stringify(packageInfo))
-                .on("progress", (event: any) => {
+            request.attach(`package`, file)
+                .field(`packageInfo`, JSON.stringify(packageInfo))
+                .on(`progress`, (event: any) => {
                     if (uploadProgressCallback && event && event.total > 0) {
                         var currentProgress: number = event.loaded / event.total * 100;
                         uploadProgressCallback(currentProgress);
@@ -616,88 +231,53 @@ export class AccountManager {
     }
 
     public promotePackage(appId: string, sourceDeploymentId: string, destDeploymentId: string): Promise<void> {
-        return Promise<void>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.post(this._serverUrl + "/apps/" + appId + "/deployments/" + sourceDeploymentId + "/promote/" + destDeploymentId);
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                if (res.ok) {
-                    resolve(<void>null);
-                } else {
-                    var body = tryJSON(res.text);
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.post(`/apps/${appId}/deployments/${sourceDeploymentId}/promote/${destDeploymentId}`, /*requestBody=*/ null, /*expectResponseBody=*/ false)
+            .then(() => null);
     }
 
     public rollbackPackage(appId: string, deploymentId: string, targetRelease?: string): Promise<void> {
-        return Promise<void>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.post(this._serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/rollback/" + (targetRelease || ""));
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                if (res.ok) {
-                    resolve(<void>null);
-                } else {
-                    var body = tryJSON(res.text);
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.post(`/apps/${appId}/deployments/${deploymentId}/rollback/${targetRelease || ``}`, /*requestBody=*/ null, /*expectResponseBody=*/ false)
+            .then(() => null);
     }
 
     public getPackage(appId: string, deploymentId: string): Promise<Package> {
-        return Promise<Package>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/package");
-            this.attachCredentials(request);
-
-            request.end((err: any, res: superagent.Response) => {
-                if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
-                    return;
-                }
-
-                var body = tryJSON(res.text);
-                if (res.ok) {
-                    if (body) {
-                        resolve(body.package);
-                    } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
-                    }
-                } else {
-                    if (body) {
-                        reject(<CodePushError>body);
-                    } else {
-                        reject(<CodePushError>{ message: res.text, statusCode: res.status });
-                    }
-                }
-            });
-        });
+        return this.get(`/apps/${appId}/deployments/${deploymentId}/package`)
+            .then((res: JsonResponse) => res.body.package);
     }
 
     public getPackageHistory(appId: string, deploymentId: string): Promise<Package[]> {
-        return Promise<Package[]>((resolve, reject, notify) => {
-            var request: superagent.Request<any> = superagent.get(this._serverUrl + "/apps/" + appId + "/deployments/" + deploymentId + "/packageHistory");
+        return this.get(`/apps/${appId}/deployments/${deploymentId}/packageHistory`)
+            .then((res: JsonResponse) => res.body.packageHistory);
+    }
+
+    private get(endpoint: string, expectResponseBody: boolean = true): Promise<JsonResponse> {
+        return this.makeApiRequest(`get`, endpoint, /*requestBody=*/ null, expectResponseBody, /*contentType=*/ null);
+    }
+
+    private post(endpoint: string, requestBody: string, expectResponseBody: boolean, contentType: string = `application/json;charset=UTF-8`): Promise<JsonResponse> {
+        return this.makeApiRequest(`post`, endpoint, requestBody, expectResponseBody, contentType);
+    }
+
+    private put(endpoint: string, requestBody: string, expectResponseBody: boolean = false, contentType: string = `application/json;charset=UTF-8`): Promise<JsonResponse> {
+        return this.makeApiRequest(`put`, endpoint, requestBody, expectResponseBody, contentType);
+    }
+
+    private del(endpoint: string, expectResponseBody: boolean = false): Promise<JsonResponse> {
+        return this.makeApiRequest(`del`, endpoint, /*requestBody=*/ null, expectResponseBody, /*contentType=*/ null);
+    }
+
+    private makeApiRequest(method: string, endpoint: string, requestBody: string, expectResponseBody: boolean, contentType: string): Promise<JsonResponse> {
+        return Promise<JsonResponse>((resolve, reject, notify) => {
+            var request: superagent.Request<any> = (<any>superagent)[method](this._serverUrl + endpoint);
             this.attachCredentials(request);
+
+            if (requestBody) {
+                if (contentType) {
+                    request = request.set(`Content-Type`, contentType);
+                }
+
+                request = request.send(requestBody);
+            }
 
             request.end((err: any, res: superagent.Response) => {
                 if (err) {
@@ -707,10 +287,13 @@ export class AccountManager {
 
                 var body = tryJSON(res.text);
                 if (res.ok) {
-                    if (body) {
-                        resolve(body.packageHistory);
+                    if (expectResponseBody && !body) {
+                        reject(<CodePushError>{ message: `Could not parse response: ${res.text}`, statusCode: res.status });
                     } else {
-                        reject(<CodePushError>{ message: "Could not parse response: " + res.text, statusCode: res.status });
+                        resolve(<JsonResponse>{
+                            header: res.header,
+                            body: body
+                        });
                     }
                 } else {
                     if (body) {
@@ -737,18 +320,18 @@ export class AccountManager {
     }
 
     private attachCredentials(request: superagent.Request<any>): void {
-        request.set("User-Agent", this._userAgent);
-        request.set("Accept", "application/vnd.code-push." + AccountManager.API_VERSION + "+json");
-        request.set("Authorization", "Bearer " + this._accessKey);
+        request.set(`User-Agent`, this._userAgent);
+        request.set(`Accept`, `application/vnd.code-push.${AccountManager.API_VERSION}+json`);
+        request.set(`Authorization`, `Bearer ${this._accessKey}`);
     }
 
     private generateAccessKey(): Promise<string> {
         return this.getAccountInfo()
             .then((account: Account) => {
                 var accessKey = crypto.randomBytes(21)
-                    .toString("base64")
-                    .replace(/\+/g, "_")  // URL-friendly characters
-                    .replace(/\//g, "-")
+                    .toString(`base64`)
+                    .replace(/\+/g, `_`)  // URL-friendly characters
+                    .replace(/\//g, `-`)
                     .concat(account.id);
 
                 return accessKey;

--- a/sdk/script/account-manager.ts
+++ b/sdk/script/account-manager.ts
@@ -1,7 +1,6 @@
 import * as base64 from "base-64";
 import Q = require("q");
 import crypto = require("crypto");
-import tryJSON = require("try-json");
 import Promise = Q.Promise;
 import superagent = require("superagent");
 
@@ -219,7 +218,11 @@ export class AccountManager {
                     if (res.ok) {
                         resolve(<void>null);
                     } else {
-                        var body = tryJSON(res.text);
+                        try {
+                            var body = JSON.parse(res.text);
+                        } catch (err) {
+                        }
+
                         if (body) {
                             reject(<CodePushError>body);
                         } else {
@@ -285,7 +288,11 @@ export class AccountManager {
                     return;
                 }
 
-                var body = tryJSON(res.text);
+                try {
+                    var body = JSON.parse(res.text);
+                } catch (err) {
+                }
+
                 if (res.ok) {
                     if (expectResponseBody && !body) {
                         reject(<CodePushError>{ message: `Could not parse response: ${res.text}`, statusCode: res.status });


### PR DESCRIPTION
This was originally intended to be done later as part of productizing the SDK, however this quick PR simplifies my other work too.

Changes:

1. Clean up/de-deduplicate all of the boilerplate. The number of lines is halved and it's much more readable. I've also found out that we have some inconsistencies with how we handle response bodies in POST requests.
2. Convert everything to use template strings
3. Remove try-json dependency