### PR TITLE
Bump versions for cli, plugin and sdk

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push-cli",
-  "version": "1.5.0-beta",
+  "version": "1.6.0-beta",
   "description": "Management CLI for the CodePush service",
   "main": "script/cli.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "base-64": "^0.1.0",
     "chalk": "^1.1.0",
     "cli-table": "^0.3.1",
-    "code-push": "1.5.0-beta",
+    "code-push": "1.6.0-beta",
     "email-validator": "^1.0.3",
     "fs": "0.0.2",
     "moment": "^2.10.6",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "1.5.2-beta",
+  "version": "1.6.0-beta",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/plugin.xml
+++ b/sdk/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="code-push" version="1.5.2-beta">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="code-push" version="1.6.0-beta">
 	<name>CodePushAcquisition</name>
 	<description>CodePush Acquisition Plugin for Apache Cordova</description>
 	<license>MIT</license>


### PR DESCRIPTION
The new collaborator feature ships with this version. 1.6.0-beta.