### PR TITLE
Move name resolution logic out of the CLI

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -457,18 +457,6 @@ function isCurrentAccountOwner(map: CollaboratorMap): boolean {
     return false;
 }
 
-function getCurrentUserEmail(map: CollaboratorMap): string {
-    if (map) {
-        for (var key of Object.keys(map)) {
-            if (map[key].isCurrentAccount) {
-                return key;
-            }
-        }
-    }
-
-    return null;
-}
-
 function getOwnerEmail(map: CollaboratorMap): string {
     if (map) {
         for (var key of Object.keys(map)) {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -18,7 +18,7 @@ import wordwrap = require("wordwrap");
 
 import * as cli from "../definitions/cli";
 import { AcquisitionStatus } from "code-push/script/acquisition-sdk";
-import { AccessKey, AccountManager, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Package, Permissions, UpdateMetrics } from "code-push";
+import { AccessKey, Account, AccountManager, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Package, Permissions, UpdateMetrics } from "code-push";
 var packageJson = require("../package.json");
 import Promise = Q.Promise;
 var progress = require("progress");

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -13,9 +13,14 @@ function assertJsonDescribesObject(json: string, object: Object): void {
 }
 
 export class SdkStub {
+    public getAccountInfo(): Promise<codePush.Account> {
+        return Q(<codePush.Account>{
+            email: "a@a.com"
+        });
+    }
+
     public addAccessKey(machine: string, description?: string): Promise<codePush.AccessKey> {
         return Q(<codePush.AccessKey>{
-            id: "accessKeyId",
             name: "key123",
             createdTime: new Date().getTime(),
             createdBy: os.hostname(),
@@ -25,7 +30,6 @@ export class SdkStub {
 
     public addApp(name: string): Promise<codePush.App> {
         return Q(<codePush.App>{
-            id: "appId",
             name: name
         });
     }
@@ -36,7 +40,6 @@ export class SdkStub {
 
     public addDeployment(appId: string, name: string): Promise<codePush.Deployment> {
         return Q(<codePush.Deployment>{
-            id: "deploymentId",
             name: name,
             key: "6"
         });
@@ -44,7 +47,6 @@ export class SdkStub {
 
     public getAccessKeys(): Promise<codePush.AccessKey[]> {
         return Q([<codePush.AccessKey>{
-            id: "7",
             name: "8",
             createdTime: 0,
             createdBy: os.hostname(),
@@ -54,11 +56,9 @@ export class SdkStub {
 
     public getApps(): Promise<codePush.App[]> {
         return Q([<codePush.App>{
-            id: "1",
             name: "a",
             collaborators: { "a@a.com": { permission: "Owner", isCurrentAccount: true } }
         }, <codePush.App>{
-            id: "2",
             name: "b",
             collaborators: { "a@a.com": { permission: "Owner", isCurrentAccount: true } }
         }]);
@@ -66,11 +66,9 @@ export class SdkStub {
 
     public getDeployments(appId: string): Promise<codePush.Deployment[]> {
         return Q([<codePush.Deployment>{
-            id: "3",
             name: "Production",
             key: "6"
         }, <codePush.Deployment>{
-            id: "4",
             name: "Staging",
             key: "6",
             package: {
@@ -231,7 +229,6 @@ describe("CLI", () => {
                 var actual: string = log.args[0][0];
                 var expected = [
                     {
-                        id: "7",
                         name: "8",
                         createdTime: 0,
                         createdBy: os.hostname(),
@@ -255,7 +252,7 @@ describe("CLI", () => {
         cmdexec.execute(command)
             .done((): void => {
                 sinon.assert.calledOnce(removeAccessKey);
-                sinon.assert.calledWithExactly(removeAccessKey, "7");
+                sinon.assert.calledWithExactly(removeAccessKey, "8");
                 sinon.assert.calledOnce(log);
                 sinon.assert.calledWithExactly(log, "Successfully removed the \"8\" access key.");
 
@@ -335,7 +332,7 @@ describe("CLI", () => {
         cmdexec.execute(command)
             .done((): void => {
                 sinon.assert.calledOnce(removeApp);
-                sinon.assert.calledWithExactly(removeApp, "1");
+                sinon.assert.calledWithExactly(removeApp, "a");
                 sinon.assert.calledOnce(log);
                 sinon.assert.calledWithExactly(log, "Successfully removed the \"a\" app.");
 
@@ -435,7 +432,7 @@ describe("CLI", () => {
                 var actual: string = log.args[0][0];
                 var expected = {
                     "collaborators":
-                        { 
+                        {
                             "a@a.com": { permission: "Owner", isCurrentAccount: true },
                             "b@b.com": { permission: "Collaborator", isCurrentAccount: false }
                         }
@@ -543,7 +540,7 @@ describe("CLI", () => {
         cmdexec.execute(command)
             .done((): void => {
                 sinon.assert.calledOnce(removeDeployment);
-                sinon.assert.calledWithExactly(removeDeployment, "1", "4");
+                sinon.assert.calledWithExactly(removeDeployment, "a", "Staging");
                 sinon.assert.calledOnce(log);
                 sinon.assert.calledWithExactly(log, "Successfully removed the \"Staging\" deployment from the \"a\" app.");
 

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -1,16 +1,25 @@
 declare module "rest-definitions" {
+    /**
+     * Annotations for properties on 'inout' interfaces:
+     * - generated: This property cannot be specified on any input requests (PUT/PATCH/POST).
+     *              As a result, generated properties are always marked as optional.
+     * - key: This property is the identifier for an object, with certain uniqueness constraints.
+     */
+
+    /*inout*/
     export interface AccessKey {
-        /*generated*/ id?: string;
-        name: string;
         createdBy: string;
         createdTime: number;
         description?: string;
+        /*key*/ name: string;
     }
 
+    /*out*/
     export interface DeploymentMetrics {
         [packageLabelOrAppVersion: string]: UpdateMetrics
     }
 
+    /*in*/
     export interface DeploymentStatusReport {
         appVersion: string;
         clientUniqueId?: string;
@@ -21,35 +30,40 @@ declare module "rest-definitions" {
         status?: string;
     }
 
+    /*in*/
     export interface DownloadReport {
         clientUniqueId: string;
         deploymentKey: string;
         label: string;
     }
 
-    export interface PackageInfo {
-        appVersion: string;
-        description: string;
-        isMandatory: boolean;
+    /*inout*/
+    interface PackageInfo {
+        appVersion?: string;
+        description?: string;
+        isMandatory?: boolean;
         /*generated*/ label?: string;
-        /*generated*/ packageHash: string;
+        /*generated*/ packageHash?: string;
     }
 
+    /*out*/
     export interface UpdateCheckResponse extends PackageInfo {
-        /*generated*/ downloadURL: string;
-        /*generated*/ isAvailable: boolean;
-        /*generated*/ packageSize: number;
-        /*generated*/ updateAppVersion?: boolean;
+        downloadURL?: string;
+        isAvailable: boolean;
+        packageSize?: number;
+        updateAppVersion?: boolean;
     }
 
+    /*in*/
     export interface UpdateCheckRequest {
         appVersion: string;
         deploymentKey: string;
-        isCompanion: boolean;
-        label: string;
-        packageHash: string;
+        isCompanion?: boolean;
+        label?: string;
+        packageHash?: string;
     }
 
+    /*out*/
     export interface UpdateMetrics {
         active: number;
         downloaded?: number;
@@ -57,35 +71,37 @@ declare module "rest-definitions" {
         installed?: number;
     }
 
+    /*inout*/
     export interface Account {
-        email: string;
-        /*generated*/ id?: string;
+        /*key*/ email: string;
         name: string;
-        /*const*/ username: string;
     }
 
+    /*out*/
     export interface CollaboratorProperties {
-        /*generated*/ isCurrentAccount?: boolean;
+        isCurrentAccount?: boolean;
         permission: string;
     }
 
+    /*out*/
     export interface CollaboratorMap {
         [email: string]: CollaboratorProperties;
     }
 
+    /*inout*/
     export interface App {
         /*generated*/ collaborators?: CollaboratorMap;
-        /*generated*/ id?: string;
-        name: string;
+        /*key*/ name: string;
     }
 
+    /*inout*/
     export interface Deployment {
-        /*generated*/ id?: string;
-        name: string;
         /*generated*/ key?: string;
-        package?: Package
+        /*key*/ name: string;
+        /*generated*/ package?: Package
     }
 
+    /*inout*/
     export interface Package extends PackageInfo {
         /*generated*/ blobUrl: string;
         /*generated*/ diffAgainstPackageHash?: string;

--- a/sdk/test/management-sdk.ts
+++ b/sdk/test/management-sdk.ts
@@ -24,15 +24,15 @@ describe("Management SDK", () => {
 
         var methodsWithErrorHandling: any[] = [
             manager.addApp.bind(manager, "appName"),
-            manager.getApp.bind(manager, "appId"),
-            manager.updateApp.bind(manager, {}),
-            manager.removeApp.bind(manager, "appId"),
+            manager.getApp.bind(manager, "appName"),
+            manager.updateApp.bind(manager, "appName", {}),
+            manager.removeApp.bind(manager, "appName"),
 
-            manager.addDeployment.bind(manager, "appId", "name"),
-            manager.getDeployment.bind(manager, "appId", "deploymentId"),
-            manager.getDeployments.bind(manager, "appId"),
-            manager.updateDeployment.bind(manager, "appId", { id: "deploymentToChange" }),
-            manager.removeDeployment.bind(manager, "appId", { id: "deploymentToChange" }),
+            manager.addDeployment.bind(manager, "appName", "deploymentName"),
+            manager.getDeployment.bind(manager, "appName", "deploymentName"),
+            manager.getDeployments.bind(manager, "appName"),
+            manager.updateDeployment.bind(manager, "appName", "deploymentName", { name: "newDeploymentName" }),
+            manager.removeDeployment.bind(manager, "appName", "deploymentName"),
 
             manager.getPackage.bind(manager, ""),
         ];
@@ -89,26 +89,25 @@ describe("Management SDK", () => {
         });
     });
 
-    it("addApp handles location header", (done: MochaDone) => {
-        mockReturn(JSON.stringify({ success: true }), 200, { location: "/appId" });
+    it("addApp handles successful response", (done: MochaDone) => {
+        mockReturn(JSON.stringify({ success: true }), 201, { location: "/appName" });
         manager.addApp("appName").done((obj) => {
             assert.ok(obj);
             done();
         }, rejectHandler);
     });
 
-    it("addApp handles missing location header", (done: MochaDone) => {
-        mockReturn(JSON.stringify({ success: true }), 200, {});
+    it("addApp handles error response", (done: MochaDone) => {
+        mockReturn(JSON.stringify({ success: false }), 404, {});
         manager.addApp("appName").done((obj) => {
-            assert.ok(!obj);
-            done();
-        }, rejectHandler);
+            throw new Error("Call should not complete successfully");
+        }, (error: Error) => done());
     });
 
     it("getApp handles JSON response", (done: MochaDone) => {
         mockReturn(JSON.stringify({ app: {} }), 200, {});
 
-        manager.getApp("appId").done((obj: any) => {
+        manager.getApp("appName").done((obj: any) => {
             assert.ok(obj);
             done();
         }, rejectHandler);
@@ -117,7 +116,7 @@ describe("Management SDK", () => {
     it("updateApp handles success response", (done: MochaDone) => {
         mockReturn(JSON.stringify({ apps: [] }), 200, {});
 
-        manager.updateApp(<any>{}).done((obj: any) => {
+        manager.updateApp("appName", <any>{}).done((obj: any) => {
             assert.ok(!obj);
             done();
         }, rejectHandler);
@@ -126,16 +125,16 @@ describe("Management SDK", () => {
     it("removeApp handles success response", (done: MochaDone) => {
         mockReturn("", 200, {});
 
-        manager.removeApp("appId").done((obj: any) => {
+        manager.removeApp("appName").done((obj: any) => {
             assert.ok(!obj);
             done();
         }, rejectHandler);
     });
 
     it("addDeployment handles success response", (done: MochaDone) => {
-        mockReturn(JSON.stringify({ deployment: { name: "name", key: "key" } }), 201, { location: "/deploymentId" });
+        mockReturn(JSON.stringify({ deployment: { name: "name", key: "key" } }), 201, { location: "/deploymentName" });
 
-        manager.addDeployment("appId", "name").done((obj: any) => {
+        manager.addDeployment("appName", "deploymentName").done((obj: any) => {
             assert.ok(obj);
             done();
         }, rejectHandler);
@@ -144,7 +143,7 @@ describe("Management SDK", () => {
     it("getDeployment handles JSON response", (done: MochaDone) => {
         mockReturn(JSON.stringify({ deployment: {} }), 200, {});
 
-        manager.getDeployment("appId", "deploymentId").done((obj: any) => {
+        manager.getDeployment("appName", "deploymentName").done((obj: any) => {
             assert.ok(obj);
             done();
         }, rejectHandler);
@@ -153,7 +152,7 @@ describe("Management SDK", () => {
     it("getDeployments handles JSON response", (done: MochaDone) => {
         mockReturn(JSON.stringify({ deployments: [] }), 200, {});
 
-        manager.getDeployments("appId").done((obj: any) => {
+        manager.getDeployments("appName").done((obj: any) => {
             assert.ok(obj);
             done();
         }, rejectHandler);
@@ -162,7 +161,7 @@ describe("Management SDK", () => {
     it("updateDeployment handles success response", (done: MochaDone) => {
         mockReturn(JSON.stringify({ apps: [] }), 200, {});
 
-        manager.updateDeployment("appId", <any>{id: "deploymentId"}).done((obj: any) => {
+        manager.updateDeployment("appName", "deploymentName", { name: "newDeploymentName" }).done((obj: any) => {
             assert.ok(!obj);
             done();
         }, rejectHandler);
@@ -171,7 +170,7 @@ describe("Management SDK", () => {
     it("removeDeployment handles success response", (done: MochaDone) => {
         mockReturn("", 200, {});
 
-        manager.removeDeployment("appId", "deploymentId").done((obj: any) => {
+        manager.removeDeployment("appName", "deploymentName").done((obj: any) => {
             assert.ok(!obj);
             done();
         }, rejectHandler);
@@ -180,7 +179,7 @@ describe("Management SDK", () => {
     it("getPackage handles success response", (done: MochaDone) => {
         mockReturn(JSON.stringify({ package: {} }), 200);
 
-        manager.getPackage("appId", "deploymentId").done((obj: any) => {
+        manager.getPackage("appName", "deploymentName").done((obj: any) => {
             assert.ok(obj);
             done();
         }, rejectHandler);
@@ -189,7 +188,7 @@ describe("Management SDK", () => {
     it("getPackageHistory handles success response with no packages", (done: MochaDone) => {
         mockReturn(JSON.stringify({ packageHistory: [] }), 200);
 
-        manager.getPackageHistory("appId", "deploymentId").done((obj: any) => {
+        manager.getPackageHistory("appName", "deploymentName").done((obj: any) => {
             assert.ok(obj);
             assert.equal(obj.length, 0);
             done();
@@ -199,7 +198,7 @@ describe("Management SDK", () => {
     it("getPackageHistory handles success response with two packages", (done: MochaDone) => {
         mockReturn(JSON.stringify({ packageHistory: [ { label: "v1" }, { label: "v2" } ] }), 200);
 
-        manager.getPackageHistory("appId", "deploymentId").done((obj: any) => {
+        manager.getPackageHistory("appName", "deploymentName").done((obj: any) => {
             assert.ok(obj);
             assert.equal(obj.length, 2);
             assert.equal(obj[0].label, "v1");
@@ -211,7 +210,7 @@ describe("Management SDK", () => {
     it("getPackageHistory handles error response", (done: MochaDone) => {
         mockReturn("", 404);
 
-        manager.getPackageHistory("appId", "deploymentId").done((obj: any) => {
+        manager.getPackageHistory("appName", "deploymentName").done((obj: any) => {
             throw new Error("Call should not complete successfully");
         }, (error: Error) => done());
     });


### PR DESCRIPTION
(Merging into 'breaking'. On the diff tab, add '?w=1' to the URL to ignore whitespace changes)

Note that the issue of disambiguating duplicate apps by email is not explicitly addressed here. I will address this in a subsequent review, but I expect that it will be a matter of URL encoding the '<email>/appName' chunk and then decoding it on the server.