### PR TITLE
Rely on server for generation of qualified app names

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -598,6 +598,7 @@ function printAppList(format: string, apps: App[], deploymentLists: string[][]):
         var dataSource: any[] = apps.map((app: App, index: number) => {
             var augmentedApp: any = app;
             augmentedApp.deployments = deploymentLists[index];
+            return augmentedApp;
         });
 
         printJson(dataSource);

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -329,8 +329,26 @@ describe("CLI", () => {
 
                 var actual: string = log.args[0][0];
                 var expected = [
-                    { name: "a", deployments: ["Production", "Staging"]},
-                    { name: "b", deployments: ["Production", "Staging"]}
+                    {
+                        name: "a",
+                        collaborators: {
+                            "a@a.com": {
+                                permission: "Owner",
+                                isCurrentAccount: true
+                            }
+                        },
+                        deployments: ["Production", "Staging"]
+                    },
+                    {
+                        name: "b",
+                        collaborators: {
+                            "a@a.com": {
+                                permission: "Owner",
+                                isCurrentAccount: true
+                            }
+                        },
+                        deployments: ["Production", "Staging"]
+                    }
                 ];
 
                 assertJsonDescribesObject(actual, expected);


### PR DESCRIPTION
(Merging into 'breaking')

The server now accepts qualified app names as input and also sends them as output where appropriate, so that this logic does not need to be performed by clients.

This will be the last set of breaking changes on the client (I didn't realize I needed to do this when I sent the wrap-up PR yesterday)