### PR TITLE
[release-react] Change default jsbundle file name for android

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -288,6 +288,7 @@ After configuring your React Native app to query for updates against the CodePus
 
 ```
 code-push release-react <appName> <platform> 
+[--bundleName <bundleName>]
 [--deploymentName <deploymentName>]
 [--description <description>]
 [--entryFile <entryFile>]
@@ -305,6 +306,10 @@ It then calls the vanilla `release` command by supplying the values for the requ
 ### Platform parameter
 
 This specifies which platform the current update is targeting, and can be either `ios` or `android` (case-insensitive).
+
+### Bundle name parameter
+
+This specifies the name of the output JS bundle file. If left unspecified, the standard bundle name will be used for the specified platform: `main.jsbundle` (iOS) and `index.android.bundle` (Android).
 
 ### Deployment name parameter
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -139,6 +139,7 @@ export interface IReleaseCommand extends IReleaseBaseCommand {
 }
 
 export interface IReleaseReactCommand extends IReleaseBaseCommand {
+    bundleName?: string;
     entryFile?: string;
     platform: string;
     sourcemapOutput?: string;

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1035,7 +1035,7 @@ export var runReactNativeBundleCommand = (entryFile: string, outputFolder: strin
     var reactNativeBundleArgs = [
         path.join("node_modules", "react-native", "local-cli", "cli.js"), "bundle",
         "--assets-dest", outputFolder,
-        "--bundle-output", path.join(outputFolder, "main.jsbundle"),
+        "--bundle-output", path.join(outputFolder, platform === "ios" ? "main.jsbundle" : "index.android.bundle"),
         "--dev", false,
         "--entry-file", entryFile,
         "--platform", platform,

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -301,6 +301,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
             .example("release-react MyApp ios", "Release the React Native iOS project in the current working directory to the \"MyApp\" app's \"Staging\" deployment")
             .example("release-react MyApp android -d Production", "Release the React Native Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment")
+            .option("bundleName", { alias: "b", default: null, demand: false, description: "The name of the output JS bundle. If unspecified, \"main.jsbundle\" or \"index.android.bundle\" will be used depending on the platform (iOS/Android)", type: "string" })
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "The deployment to publish the update to", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
             .option("entryFile", { alias: "e", default: null, demand: false, description: "The path to the root JS file. If unspecified, \"index.<platform>.js\" and then \"index.js\" will be tried and used if they exist.", type: "string" })
@@ -574,7 +575,8 @@ function createCommand(): cli.ICommand {
 
                     releaseReactCommand.appName = arg1;
                     releaseReactCommand.platform = arg2;
-
+                    
+                    releaseReactCommand.bundleName = argv["bundleName"];
                     releaseReactCommand.deploymentName = argv["deploymentName"];
                     releaseReactCommand.description = argv["description"] ? backslash(argv["description"]) : "";
                     releaseReactCommand.entryFile = argv["entryFile"];

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -301,7 +301,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
             .example("release-react MyApp ios", "Release the React Native iOS project in the current working directory to the \"MyApp\" app's \"Staging\" deployment")
             .example("release-react MyApp android -d Production", "Release the React Native Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment")
-            .option("bundleName", { alias: "b", default: null, demand: false, description: "The name of the output JS bundle. If unspecified, \"main.jsbundle\" or \"index.android.bundle\" will be used depending on the platform (iOS/Android)", type: "string" })
+            .option("bundleName", { alias: "b", default: null, demand: false, description: "The name of the output JS bundle. If omitted, the standard bundle name will be used for the specified platform: \"main.jsbundle\" (iOS) and \"index.android.bundle\" (Android)", type: "string" })
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "The deployment to publish the update to", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
             .option("entryFile", { alias: "e", default: null, demand: false, description: "The path to the root JS file. If unspecified, \"index.<platform>.js\" and then \"index.js\" will be tried and used if they exist.", type: "string" })

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -813,6 +813,42 @@ describe("CLI", () => {
     });
 
     it("release-react defaults entry file to index.{platform}.js if not provided", (done: MochaDone): void => {
+        var bundleName = "bundle.js";
+        var command: cli.IReleaseReactCommand = {
+            type: cli.CommandType.releaseReact,
+            appName: "a",
+            bundleName: bundleName,
+            deploymentName: "Staging",
+            description: "Test default entry file",
+            mandatory: false,
+            platform: "ios"
+        };
+
+        ensureInTestAppDirectory();
+
+        var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release", () => { return Q(<void>null) });
+
+        cmdexec.execute(command)
+            .then(() => {
+                var releaseCommand: cli.IReleaseCommand = <any>command;
+                releaseCommand.package = path.join(os.tmpdir(), "CodePush");
+                releaseCommand.appStoreVersion = "1.2.3";
+
+                sinon.assert.calledOnce(spawn);
+                var spawnCommand: string = spawn.args[0][0];
+                var spawnCommandArgs: string = spawn.args[0][1].join(" ");
+                assert.equal(spawnCommand, "node");
+                assert.equal(
+                    spawnCommandArgs,
+                    `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(os.tmpdir(), "CodePush")} --bundle-output ${path.join(os.tmpdir(), "CodePush", bundleName)} --dev false --entry-file index.ios.js --platform ios`
+                );
+                assertJsonDescribesObject(JSON.stringify(release.args[0][0], /*replacer=*/ null, /*spacing=*/ 2), releaseCommand);
+                done();
+            })
+            .done();
+    });
+
+    it("release-react defaults bundle name to \"main.jsbundle\" if not provided and platform is \"ios\"", (done: MochaDone): void => {
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
             appName: "a",
@@ -845,11 +881,47 @@ describe("CLI", () => {
             })
             .done();
     });
-
-    it("release-react generates sourcemaps", (done: MochaDone): void => {
+    
+    it("release-react defaults bundle name to \"index.android.bundle\" if not provided and platform is \"android\"", (done: MochaDone): void => {
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
             appName: "a",
+            deploymentName: "Staging",
+            description: "Test default entry file",
+            mandatory: false,
+            platform: "android"
+        };
+
+        ensureInTestAppDirectory();
+
+        var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release", () => { return Q(<void>null) });
+
+        cmdexec.execute(command)
+            .then(() => {
+                var releaseCommand: cli.IReleaseCommand = <any>command;
+                releaseCommand.package = path.join(os.tmpdir(), "CodePush");
+                releaseCommand.appStoreVersion = "1.2.3";
+
+                sinon.assert.calledOnce(spawn);
+                var spawnCommand: string = spawn.args[0][0];
+                var spawnCommandArgs: string = spawn.args[0][1].join(" ");
+                assert.equal(spawnCommand, "node");
+                assert.equal(
+                    spawnCommandArgs,
+                    `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(os.tmpdir(), "CodePush")} --bundle-output ${path.join(os.tmpdir(), "CodePush", "index.android.bundle")} --dev false --entry-file index.android.js --platform android`
+                );
+                assertJsonDescribesObject(JSON.stringify(release.args[0][0], /*replacer=*/ null, /*spacing=*/ 2), releaseCommand);
+                done();
+            })
+            .done();
+    });
+    
+    it("release-react generates sourcemaps", (done: MochaDone): void => {
+        var bundleName = "bundle.js";
+        var command: cli.IReleaseReactCommand = {
+            type: cli.CommandType.releaseReact,
+            appName: "a",
+            bundleName: bundleName,
             deploymentName: "Staging",
             description: "Test generates sourcemaps",
             mandatory: false,
@@ -873,7 +945,7 @@ describe("CLI", () => {
                 assert.equal(spawnCommand, "node");
                 assert.equal(
                     spawnCommandArgs,
-                    `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(os.tmpdir(), "CodePush")} --bundle-output ${path.join(os.tmpdir(), "CodePush", "index.android.bundle")} --dev false --entry-file index.android.js --platform android --sourcemap-output index.android.js.map`
+                    `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(os.tmpdir(), "CodePush")} --bundle-output ${path.join(os.tmpdir(), "CodePush", bundleName)} --dev false --entry-file index.android.js --platform android --sourcemap-output index.android.js.map`
                 );
                 assertJsonDescribesObject(JSON.stringify(release.args[0][0], /*replacer=*/ null, /*spacing=*/ 2), releaseCommand);
                 done();

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -873,7 +873,7 @@ describe("CLI", () => {
                 assert.equal(spawnCommand, "node");
                 assert.equal(
                     spawnCommandArgs,
-                    `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(os.tmpdir(), "CodePush")} --bundle-output ${path.join(os.tmpdir(), "CodePush", "main.jsbundle")} --dev false --entry-file index.android.js --platform android --sourcemap-output index.android.js.map`
+                    `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(os.tmpdir(), "CodePush")} --bundle-output ${path.join(os.tmpdir(), "CodePush", "index.android.bundle")} --dev false --entry-file index.android.js --platform android --sourcemap-output index.android.js.map`
                 );
                 assertJsonDescribesObject(JSON.stringify(release.args[0][0], /*replacer=*/ null, /*spacing=*/ 2), releaseCommand);
                 done();


### PR DESCRIPTION
To "index.android.bundle", to match RN's default https://github.com/facebook/react-native/blob/master/local-cli/generator-android/templates/src/app/react.gradle#L5