### PR TITLE
Do not remove the access key on logout if we logged in via '--accessKey'

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -59,17 +59,13 @@ If you need additional keys that can be used to authenticate against the CodePus
 code-push access-key add "VSTS Integration"
 ```
 
-After creating the new key, you can specify its value using the `--accessKey` flag of the `login` command, which allows you to perform the "headless" authentication, as opposed to launching a browser.
+After creating the new key, you can specify its value using the `--accessKey` flag of the `login` command, which allows you to perform "headless" authentication, as opposed to launching a browser.
 
 ```
 code-push login --accessKey <accessKey>
 ```
 
-If you want to log out of your current session, but still be able to reuse the same key for future logins, run the following command:
-
-```
-code-push logout --local
-```
+When logging in via this method, the access key will not be automatically invalidated on logout, and can be used in future sessions until it is explicitly removed.
 
 ## App management
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -65,7 +65,7 @@ After creating the new key, you can specify its value using the `--accessKey` fl
 code-push login --accessKey <accessKey>
 ```
 
-When logging in via this method, the access key will not be automatically invalidated on logout, and can be used in future sessions until it is explicitly removed.
+When logging in via this method, the access key will not be automatically invalidated on logout, and can be used in future sessions until it is explicitly removed from the CodePush server. However, it is still recommended to log out once your session is complete, in order to remove your credentials from disk.
 
 ## App management
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -113,7 +113,6 @@ export interface ILoginCommand extends ICommand {
 }
 
 export interface ILogoutCommand extends ICommand {
-    isLocal: boolean;
 }
 
 export interface IPromoteCommand extends ICommand {

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -112,9 +112,6 @@ export interface ILoginCommand extends ICommand {
     accessKey: string;
 }
 
-export interface ILogoutCommand extends ICommand {
-}
-
 export interface IPromoteCommand extends ICommand {
     appName: string;
     sourceDeploymentName: string;

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -450,7 +450,7 @@ export function execute(command: cli.ICommand): Promise<void> {
                     return login(<cli.ILoginCommand>command);
 
                 case cli.CommandType.logout:
-                    return logout(<cli.ILogoutCommand>command);
+                    return logout(command);
 
                 case cli.CommandType.promote:
                     return promote(<cli.IPromoteCommand>command);
@@ -552,7 +552,7 @@ function loginWithExternalAuthentication(action: string, serverUrl?: string): Pr
         });
 }
 
-function logout(command: cli.ILogoutCommand): Promise<void> {
+function logout(command: cli.ICommand): Promise<void> {
     return Q(<void>null)
         .then((): Promise<void> => {
             if (!connectionInfo.preserveAccessKeyOnLogout) {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -42,14 +42,10 @@ interface NameToCountMap {
 /** Deprecated */
 interface ILegacyLoginConnectionInfo {
     accessKeyName: string;
-    // The 'providerName' property has been obsoleted
-    // The 'providerUniqueId' property has been obsoleted
-    // The 'serverUrl' property has been obsoleted
 }
 
 interface ILoginConnectionInfo {
     accessKey: string;
-    // The 'serverUrl' property has been obsoleted
     customServerUrl?: string;   // A custom serverUrl for internal debugging purposes
     preserveAccessKeyOnLogout?: boolean;
 }
@@ -557,7 +553,6 @@ function loginWithExternalAuthentication(action: string, serverUrl?: string): Pr
 }
 
 function logout(command: cli.ILogoutCommand): Promise<void> {
-    var delayedError: Error;
     return Q(<void>null)
         .then((): Promise<void> => {
             if (!connectionInfo.preserveAccessKeyOnLogout) {
@@ -565,16 +560,11 @@ function logout(command: cli.ILogoutCommand): Promise<void> {
                     .then((): void => {
                         log(`Removed access key ${sdk.accessKey}.`);
                     });
-            } else {
-                log("Warning: Your access key is still valid for future sessions. Please explicitly remove it if desired.");
             }
         })
-        .catch((err: Error) => delayedError = err)
-        .then((): void => {
+        .finally((): void => {
             sdk = null;
             deleteConnectionInfoCache();
-
-            if (delayedError) throw delayedError;
         });
 }
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -264,7 +264,6 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         yargs.usage(USAGE_PREFIX + " logout")
             .demand(/*count*/ 1, /*max*/ 1)  // Require exactly one non-option argument.
             .example("logout", "Log out and end your session");
-            // The 'logout --local' option is obsoleted
         addCommonConfiguration(yargs);
     })
     .command("promote", "Promote the package from one deployment of your app to another", (yargs: yargs.Argv) => {

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -261,11 +261,10 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
     .command("logout", "Log out of the current session", (yargs: yargs.Argv) => {
         isValidCommandCategory = true;
         isValidCommand = true;
-        yargs.usage(USAGE_PREFIX + " logout [--local]")
+        yargs.usage(USAGE_PREFIX + " logout")
             .demand(/*count*/ 1, /*max*/ 1)  // Require exactly one non-option argument.
-            .example("logout", "Log out and also remove the access key used for the current session")
-            .example("logout --local", "Log out but allow the use of the same access key for future logins")
-            .option("local", { demand: false, description: "Whether to delete the current session's access key on the server", type: "boolean" });
+            .example("logout", "Log out and end your session");
+            // The 'logout --local' option is obsoleted
         addCommonConfiguration(yargs);
     })
     .command("promote", "Promote the package from one deployment of your app to another", (yargs: yargs.Argv) => {
@@ -526,10 +525,6 @@ function createCommand(): cli.ICommand {
 
             case "logout":
                 cmd = { type: cli.CommandType.logout };
-
-                var logoutCommand = <cli.ILogoutCommand>cmd;
-
-                logoutCommand.isLocal = argv["local"];
                 break;
 
             case "promote":
@@ -575,7 +570,7 @@ function createCommand(): cli.ICommand {
 
                     releaseReactCommand.appName = arg1;
                     releaseReactCommand.platform = arg2;
-                    
+
                     releaseReactCommand.bundleName = argv["bundleName"];
                     releaseReactCommand.deploymentName = argv["deploymentName"];
                     releaseReactCommand.description = argv["description"] ? backslash(argv["description"]) : "";


### PR DESCRIPTION
This is especially important for the HockeyApp integration, as HockeyApp customers will be logging in with their HockeyApp API key, and need it to persist across multiple sessions.

In future it would make sense to store metadata about how the access key was generated on the server, but regardless of whether we do that it makes sense to me to do this particular piece on the client so that we don't need to consult with the server.