### PR TITLE
Let updates target a range of binary versions

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -344,9 +344,9 @@ This is the same parameter as the one described in the [above section](#mandator
 
 This specifies the relative path to where the sourcemap file for resulting update's JS bundle should be generated. If left unspecified, sourcemaps will not be generated.
 
-### Target binary range parameter
+### Target binary version parameter
 
-This is the same parameter as the one described in the [above section](#target-binary-range-parameter). If left unspecified, the command defaults to targeting only the specified version in the project's metadata (`Info.plist` if this update is for iOS clients, and `build.gradle` for Android clients).
+This is the same parameter as the one described in the [above section](#target-binary-version-parameter). If left unspecified, the command defaults to targeting only the specified version in the project's metadata (`Info.plist` if this update is for iOS clients, and `build.gradle` for Android clients).
 
 ## Promoting updates across deployments
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -206,12 +206,12 @@ When the metrics cell reports `No installs recorded`, that indicates that the se
 
 ## Releasing app updates
 
-*NOTE: If your app is built using React Native, we have a different command that automates generating the update contents and inferring some of the parameters (e.g. `targetBinaryRange`) from the project's metadata. Check out the section: [Releasing updates to a React Native app](#releasing-updates-to-a-react-native-app).*
+*NOTE: If your app is built using React Native, we have a different command that automates generating the update contents and inferring some of the parameters (e.g. `targetBinaryVersion`) from the project's metadata. Check out the section: [Releasing updates to a React Native app](#releasing-updates-to-a-react-native-app).*
 
 Once your app has been configured to query for updates against the CodePush service--using your desired deployment--you can begin pushing updates to it using the following command:
 
 ```
-code-push release <appName> <updateContents> <targetBinaryRange>
+code-push release <appName> <updateContents> <targetBinaryVersion>
 [--deploymentName <deploymentName>]
 [--description <description>]
 [--mandatory]
@@ -232,9 +232,15 @@ It's important that the path you specify refers to the platform-specific, prepar
 | React Native wo/assets (iOS)     | `react-native bundle --platform ios --entry-file <entryFile> --bundle-output <bundleOutput> --dev false`                                                   | Value of the `--bundle-output` option                                                                 |
 | React Native w/assets (iOS)      | `react-native bundle --platform ios --entry-file <entryFile> --bundle-output <releaseFolder>/<bundleOutput> --assets-dest <releaseFolder> --dev false` | Value of the `--assets-dest` option, which should represent a newly created directory that includes your assets and JS bundle |
 
-### Target binary range parameter
+### Target binary version parameter
 
-This specifies a [semver range expression](https://github.com/npm/node-semver#advanced-range-syntax) that covers all the store/binary versions that this update applies to. Any client device running a version of the binary that satisfies the range expression (i.e. `semver.satisfies(version, range)` returns `true`) will get the update. Examples of valid semver range expressions are as follows:
+This specifies the store/binary version of the application you are releasing the update for, so that only users running that version will receive the update, while users running an older and/or newer version of the app binary will not. This is useful for the following reasons:
+
+1. If a user is running an older binary version, it's possible that there are breaking changes in the CodePush update that wouldn't be compatible with what they're running.
+
+2. If a user is running a newer binary version, then it's presumed that what they are running is newer (and potentially incompatible) with the CodePush update.
+
+If you ever want an update to target multiple versions of the app store binary, we also allow you to specify the parameter as a [semver range expression](https://github.com/npm/node-semver#advanced-range-syntax). That way, any client device running a version of the binary that satisfies the range expression (i.e. `semver.satisfies(version, range)` returns `true`) will get the update. Examples of valid semver range expressions are as follows:
 
 | Range Expression | Who gets the update                                                                    |
 |------------------|----------------------------------------------------------------------------------------|
@@ -247,13 +253,7 @@ This specifies a [semver range expression](https://github.com/npm/node-semver#ad
 | `^1.2.3`         | Equivalent to `>=1.2.3 <2.0.0`                                                         |
 
 *NOTE: If your semver expression starts with a special shell character or operator such as `>`, `^`, or **
-*, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.*
-
-You would want to restrict updates to target specific binary versions of your app, for the following reasons:
-
-1. If a user is running an older binary version, it's possible that there are breaking changes in the CodePush update that wouldn't be compatible with what they're running.
-
-2. If a user is running a newer binary version, then it's presumed that what they are running is newer (and potentially incompatible) with the CodePush update.
+*, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryVersion` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.*
 
 The following table outlines the version value that CodePush expects your update's semver range to satisfy for each respective app type:
 
@@ -316,9 +316,9 @@ code-push release-react <appName> <platform>
 This `release-react` command does two things in addition to running the vanilla `release` command described in the [previous section](#releasing-app-updates):
 
 1. It runs the [`react-native bundle` command](#update-contents-parameter) to generate the update contents in a temporary folder
-2. It infers the [`targetBinaryRange` of this release](#target-binary-range-parameter) by reading the contents of the project's metadata (`Info.plist` if this update is for iOS clients, and `build.gradle` for Android clients), and defaults to target only the specified version in the metadata.
+2. It infers the [`targetBinaryVersion` of this release](#target-binary-range-parameter) by reading the contents of the project's metadata (`Info.plist` if this update is for iOS clients, and `build.gradle` for Android clients), and defaults to target only the specified version in the metadata.
 
-It then calls the vanilla `release` command by supplying the values for the required parameters using the above information. Doing this helps you avoid the manual step of generating the update contents yourself using the `react-native bundle` command and also avoid common pitfalls such as supplying a wrong `targetBinaryRange` parameter.
+It then calls the vanilla `release` command by supplying the values for the required parameters using the above information. Doing this helps you avoid the manual step of generating the update contents yourself using the `react-native bundle` command and also avoid common pitfalls such as supplying an invalid `targetBinaryVersion` parameter.
 
 ### Platform parameter
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -244,19 +244,23 @@ This specifies a [semver range expression](https://github.com/npm/node-semver#ad
 | `^1.2.3`         | Equivalent to `>=1.2.3 <2.0.0`                                                         |
 | `*`              | Any device configured to consume updates from your CodePush app                        |
 
+*NOTE: If your semver expression starts with a special shell character, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.
+
 You would want to restrict updates to target specific binary versions of your app, for the following reasons:
 
 1. If a user is running an older binary version, it's possible that there are breaking changes in the CodePush update that wouldn't be compatible with what they're running.
 
 2. If a user is running a newer binary version, then it's presumed that what they are running is newer (and potentially incompatible) with the CodePush update.
 
-The following table outlines the semver value that CodePush expects your range to satisfy for each respective app type:
+The following table outlines the version value that CodePush expects your update's semver range to satisfy for each respective app type:
 
 | Platform               | Source of app store version                                                  |
 |------------------------|------------------------------------------------------------------------------|
 | Cordova                | The `<widget version>` attribute in the `config.xml` file                    |
 | React Native (Android) | The `android.defaultConfig.versionName` property in your `build.gradle` file |
 | React Native (iOS)     | The `CFBundleShortVersionString` key in the `Info.plist` file                |
+
+*NOTE: If the app store version in the metadata files are missing a patch version, e.g. `2.0`, it will be treated as having a patch version of `0`, i.e. `2.0 -> 2.0.0`.
 
 ### Deployment name parameter
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -347,7 +347,7 @@ This specifies the relative path to where the sourcemap file for resulting updat
 
 ### Target binary range parameter
 
-This is the same parameter as the one described in the [above section](#target-binary-range-parameter).
+This is the same parameter as the one described in the [above section](#target-binary-range-parameter). If left unspecified, the command defaults to targeting only the specified version in the project's metadata (`Info.plist` if this update is for iOS clients, and `build.gradle` for Android clients).
 
 ## Promoting updates across deployments
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -244,7 +244,7 @@ This specifies a [semver range expression](https://github.com/npm/node-semver#ad
 | `^1.2.3`         | Equivalent to `>=1.2.3 <2.0.0`                                                         |
 | `*`              | Any device configured to consume updates from your CodePush app                        |
 
-*NOTE: If your semver expression starts with a special shell character, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.
+*NOTE: If your semver expression starts with a special shell character or operator such as `>` or `^`, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.
 
 You would want to restrict updates to target specific binary versions of your app, for the following reasons:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -238,8 +238,8 @@ This specifies a [semver range expression](https://github.com/npm/node-semver#ad
 
 | Range Expression | Who gets the update                                                                    |
 |------------------|----------------------------------------------------------------------------------------|
-| `1.2.3`          | Devices running the binary app store version `1.2.3` of your app                       |
-| `1.2.*`          | Devices running major version 1, minor version 2 and any patch version app             |
+| `1.2.3`          | Only devices running the specific binary app store version `1.2.3` of your app         |
+| `1.2.*`          | Devices running major version 1, minor version 2 and any patch version of your app     |
 | `>=1.2.3 <1.2.7` | Devices running any binary version between `1.2.3` (inclusive) and `1.2.7` (exclusive) |
 | `^1.2.3`         | Equivalent to `>=1.2.3 <2.0.0`                                                         |
 | `*`              | Any device configured to consume updates from your CodePush app                        |

--- a/cli/README.md
+++ b/cli/README.md
@@ -246,7 +246,7 @@ This specifies a [semver range expression](https://github.com/npm/node-semver#ad
 | `~1.2.3`         | Equivalent to `>=1.2.3 <1.3.0`                                                         |
 | `^1.2.3`         | Equivalent to `>=1.2.3 <2.0.0`                                                         |
 
-*NOTE: If your semver expression starts with a special shell character or operator such as `>`, `^`, or *`*`*, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.
+*NOTE: If your semver expression starts with a special shell character or operator such as `>`, `^`, or *`*`*, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.*
 
 You would want to restrict updates to target specific binary versions of your app, for the following reasons:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -246,7 +246,7 @@ This specifies a [semver range expression](https://github.com/npm/node-semver#ad
 | `~1.2.3`         | Equivalent to `>=1.2.3 <1.3.0`                                                         |
 | `^1.2.3`         | Equivalent to `>=1.2.3 <2.0.0`                                                         |
 
-*NOTE: If your semver expression starts with a special shell character or operator such as `>`, `^`, or `***`, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.
+*NOTE: If your semver expression starts with a special shell character or operator such as `>`, `^`, or *`*`*, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.
 
 You would want to restrict updates to target specific binary versions of your app, for the following reasons:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -246,7 +246,8 @@ This specifies a [semver range expression](https://github.com/npm/node-semver#ad
 | `~1.2.3`         | Equivalent to `>=1.2.3 <1.3.0`                                                         |
 | `^1.2.3`         | Equivalent to `>=1.2.3 <2.0.0`                                                         |
 
-*NOTE: If your semver expression starts with a special shell character or operator such as `>`, `^`, or *`*`*, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.*
+*NOTE: If your semver expression starts with a special shell character or operator such as `>`, `^`, or **
+*, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.*
 
 You would want to restrict updates to target specific binary versions of your app, for the following reasons:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -239,12 +239,14 @@ This specifies a [semver range expression](https://github.com/npm/node-semver#ad
 | Range Expression | Who gets the update                                                                    |
 |------------------|----------------------------------------------------------------------------------------|
 | `1.2.3`          | Only devices running the specific binary app store version `1.2.3` of your app         |
-| `1.2.*`          | Devices running major version 1, minor version 2 and any patch version of your app     |
-| `>=1.2.3 <1.2.7` | Devices running any binary version between `1.2.3` (inclusive) and `1.2.7` (exclusive) |
-| `^1.2.3`         | Equivalent to `>=1.2.3 <2.0.0`                                                         |
 | `*`              | Any device configured to consume updates from your CodePush app                        |
+| `1.2.x`          | Devices running major version 1, minor version 2 and any patch version of your app     |
+| `1.2.3 - 1.2.7`  | Devices running any binary version between `1.2.3` (inclusive) and `1.2.7` (inclusive) |
+| `>=1.2.3 <1.2.7` | Devices running any binary version between `1.2.3` (inclusive) and `1.2.7` (exclusive) |
+| `~1.2.3`         | Equivalent to `>=1.2.3 <1.3.0`                                                         |
+| `^1.2.3`         | Equivalent to `>=1.2.3 <2.0.0`                                                         |
 
-*NOTE: If your semver expression starts with a special shell character or operator such as `>` or `^`, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.
+*NOTE: If your semver expression starts with a special shell character or operator such as `>`, `^`, or `***`, the command may not execute correctly if you do not wrap the value in quotes as the shell will not supply the right values to our CLI process. Therefore, it is best to wrap your `targetBinaryRange` parameter in double quotes when calling the `release` command, e.g. `code-push release MyApp updateContents ">1.2.3"`.
 
 You would want to restrict updates to target specific binary versions of your app, for the following reasons:
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -128,13 +128,13 @@ export interface IRegisterCommand extends ICommand {
 
 export interface IReleaseBaseCommand extends ICommand {
     appName: string;
+    appStoreVersion: string;
     deploymentName: string;
     description: string;
     mandatory: boolean;
 }
 
 export interface IReleaseCommand extends IReleaseBaseCommand {
-    appStoreVersion: string;
     package: string;
 }
 

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -741,6 +741,7 @@ function getPackageMetricsString(packageObject: PackageWithMetrics): string {
 }
 
 function getReactNativeProjectAppVersion(platform: string, projectName: string): Promise<string> {
+    var missingPatchVersionRegex = /^\d+\.\d+$/;
     if (platform === "ios") {
         try {
             var infoPlistContainingFolder: string = path.join("iOS", projectName);
@@ -761,6 +762,12 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string):
         }
 
         if (parsedInfoPlist && parsedInfoPlist.CFBundleShortVersionString) {
+            if (semver.valid(parsedInfoPlist.CFBundleShortVersionString) || missingPatchVersionRegex.test(parsedInfoPlist.CFBundleShortVersionString)) {
+                return Q(parsedInfoPlist.CFBundleShortVersionString);
+            } else {
+                throw new Error("Please update \"" + infoPlistContainingFolder + "/Info.plist\" to use a semver-compliant \"CFBundleShortVersionString\", for example \"1.0.3\".");
+            }
+            
             if (semver.valid(parsedInfoPlist.CFBundleShortVersionString) === null) {
                 throw new Error(`Please update "${infoPlistContainingFolder}/Info.plist" to use a semver-compliant \"CFBundleShortVersionString\", for example "1.0.3".`);
             } else {
@@ -782,10 +789,10 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string):
             .then((buildGradle: any) => {
                 if (buildGradle.android && buildGradle.android.defaultConfig && buildGradle.android.defaultConfig.versionName) {
                     var appVersion: string = buildGradle.android.defaultConfig.versionName.replace(/"/g, "").trim();
-                    if (semver.valid(appVersion) === null) {
-                        throw new Error("Please update \"android/app/build.gradle\" to use a semver-compliant \"android.defaultConfig.versionName\", for example \"1.0.3\".");
-                    } else {
+                    if (semver.valid(appVersion) || missingPatchVersionRegex.test(appVersion)) {
                         return appVersion;
+                    } else {
+                        throw new Error("Please update \"android/app/build.gradle\" to use a semver-compliant \"android.defaultConfig.versionName\", for example \"1.0.3\".");
                     }
                 } else {
                     throw new Error("The \"android/app/build.gradle\" file does not include a value for android.defaultConfig.versionName.");
@@ -840,8 +847,8 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
 export var release = (command: cli.IReleaseCommand): Promise<void> => {
     if (isBinaryOrZip(command.package)) {
         throw new Error("It is unnecessary to package releases in a .zip or binary file. Please specify the direct path to the update content's directory (e.g. /platforms/ios/www) or file (e.g. main.jsbundle).");
-    } else if (semver.valid(command.appStoreVersion) === null) {
-        throw new Error("Please use a semver-compliant app store version, for example \"1.0.3\".");
+    } else if (semver.validRange(command.appStoreVersion) === null) {
+        throw new Error("Please use a semver-compliant target binary version range, for example \"^1.0.3\".");
     }
 
     var filePath: string = command.package;
@@ -965,8 +972,16 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
             throw new Error(`Entry file "${entryFile}" does not exist.`);
         }
     }
+    
+    if (command.appStoreVersion && semver.validRange(command.appStoreVersion) === null) {
+        throw new Error("Please use a semver-compliant target binary version range, for example \"^1.0.3\".");
+    }
+    
+    var appVersionPromise: Promise<string> = command.appStoreVersion
+        ? Q(command.appStoreVersion)
+        : getReactNativeProjectAppVersion(platform, projectName);
 
-    return getReactNativeProjectAppVersion(platform, projectName)
+    return appVersionPromise
         .then((appVersion: string) => {
             releaseCommand.appStoreVersion = appVersion;
             return createEmptyTempReleaseFolder(outputFolder);

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -741,7 +741,7 @@ function getPackageMetricsString(packageObject: PackageWithMetrics): string {
 }
 
 function getReactNativeProjectAppVersion(platform: string, projectName: string): Promise<string> {
-    var missingPatchVersionRegex = /^\d+\.\d+$/;
+    var missingPatchVersionRegex: RegExp = /^\d+\.\d+$/;
     if (platform === "ios") {
         try {
             var infoPlistContainingFolder: string = path.join("iOS", projectName);
@@ -841,10 +841,9 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
 export var release = (command: cli.IReleaseCommand): Promise<void> => {
     if (isBinaryOrZip(command.package)) {
         throw new Error("It is unnecessary to package releases in a .zip or binary file. Please specify the direct path to the update content's directory (e.g. /platforms/ios/www) or file (e.g. main.jsbundle).");
-    } else if (semver.validRange(command.appStoreVersion) === null) {
-        throw new Error("Please use a semver-compliant target binary version range, for example \"1.0.0\", \"*\" or \"^1.2.3\".");
-    }
-
+    } 
+    
+    throwForInvalidSemverRange(command.appStoreVersion);
     var filePath: string = command.package;
     var getPackageFilePromise: Promise<IPackageFile>;
     var isSingleFilePackage: boolean = true;
@@ -967,8 +966,8 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
         }
     }
     
-    if (command.appStoreVersion && semver.validRange(command.appStoreVersion) === null) {
-        throw new Error("Please use a semver-compliant target binary version range, for example \"1.0.0\", \"*\" or \"^1.2.3\".");
+    if (command.appStoreVersion) {
+        throwForInvalidSemverRange(command.appStoreVersion);
     }
     
     var appVersionPromise: Promise<string> = command.appStoreVersion
@@ -1092,6 +1091,12 @@ function throwForInvalidEmail(email: string): void {
         throw new Error("\"" + email + "\" is an invalid e-mail address.");
     }
 }
+
+function throwForInvalidSemverRange(semverRange: string): void {
+    if (semver.validRange(semverRange) === null) {
+        throw new Error("Please use a semver-compliant target binary version range, for example \"1.0.0\", \"*\" or \"^1.2.3\".");
+    }
+} 
 
 function throwForInvalidOutputFormat(format: string): void {
     switch (format) {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -765,13 +765,7 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string):
             if (semver.valid(parsedInfoPlist.CFBundleShortVersionString) || missingPatchVersionRegex.test(parsedInfoPlist.CFBundleShortVersionString)) {
                 return Q(parsedInfoPlist.CFBundleShortVersionString);
             } else {
-                throw new Error("Please update \"" + infoPlistContainingFolder + "/Info.plist\" to use a semver-compliant \"CFBundleShortVersionString\", for example \"1.0.3\".");
-            }
-            
-            if (semver.valid(parsedInfoPlist.CFBundleShortVersionString) === null) {
-                throw new Error(`Please update "${infoPlistContainingFolder}/Info.plist" to use a semver-compliant \"CFBundleShortVersionString\", for example "1.0.3".`);
-            } else {
-                return Q(parsedInfoPlist.CFBundleShortVersionString);
+                throw new Error(`The "CFBundleShortVersionString" key in "${infoPlistContainingFolder}/Info.plist" needs to have at least a major and minor version, for example "2.0" or "1.0.3".`);
             }
         } else {
             throw new Error(`The "CFBundleShortVersionString" key does not exist in "${infoPlistContainingFolder}/Info.plist".`);
@@ -792,7 +786,7 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string):
                     if (semver.valid(appVersion) || missingPatchVersionRegex.test(appVersion)) {
                         return appVersion;
                     } else {
-                        throw new Error("Please update \"android/app/build.gradle\" to use a semver-compliant \"android.defaultConfig.versionName\", for example \"1.0.3\".");
+                        throw new Error("The \"android.defaultConfig.versionName\" property in \"android/app/build.gradle\" needs to have at least a major and minor version, for example \"2.0\" or \"1.0.3\".");
                     }
                 } else {
                     throw new Error("The \"android/app/build.gradle\" file does not include a value for android.defaultConfig.versionName.");

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -848,7 +848,7 @@ export var release = (command: cli.IReleaseCommand): Promise<void> => {
     if (isBinaryOrZip(command.package)) {
         throw new Error("It is unnecessary to package releases in a .zip or binary file. Please specify the direct path to the update content's directory (e.g. /platforms/ios/www) or file (e.g. main.jsbundle).");
     } else if (semver.validRange(command.appStoreVersion) === null) {
-        throw new Error("Please use a semver-compliant target binary version range, for example \"^1.0.3\".");
+        throw new Error("Please use a semver-compliant target binary version range, for example \"1.0.0\", \"*\" or \"^1.2.3\".");
     }
 
     var filePath: string = command.package;
@@ -974,7 +974,7 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
     }
     
     if (command.appStoreVersion && semver.validRange(command.appStoreVersion) === null) {
-        throw new Error("Please use a semver-compliant target binary version range, for example \"^1.0.3\".");
+        throw new Error("Please use a semver-compliant target binary version range, for example \"1.0.0\", \"*\" or \"^1.2.3\".");
     }
     
     var appVersionPromise: Promise<string> = command.appStoreVersion

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -286,10 +286,10 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         addCommonConfiguration(yargs);
     })
     .command("release", "Release a new version of your app to a specific deployment", (yargs: yargs.Argv) => {
-        yargs.usage(USAGE_PREFIX + " release <appName> <updateContentsPath> <targetBinaryVersion> [--deploymentName <deploymentName>] [--description <description>] [--mandatory]")
+        yargs.usage(USAGE_PREFIX + " release <appName> <updateContentsPath> <targetBinaryRange> [--deploymentName <deploymentName>] [--description <description>] [--mandatory]")
             .demand(/*count*/ 4, /*max*/ 4)  // Require exactly four non-option arguments.
-            .example("release MyApp app.js 1.0.3", "Release the \"app.js\" file to the \"MyApp\" app's \"Staging\" deployment, targeting the 1.0.3 binary version")
-            .example("release MyApp ./platforms/ios/www 1.0.3 -d Production", "Release the \"./platforms/ios/www\" folder and all its contents to the \"MyApp\" app's \"Production\" deployment, targeting the 1.0.3 binary version")
+            .example("release MyApp app.js \"*\"", "Release the \"app.js\" file to the \"MyApp\" app's \"Staging\" deployment, targeting any binary version using the \"*\" wildcard range syntax.")
+            .example("release MyApp ./platforms/ios/www 1.0.3 -d Production", "Release the \"./platforms/ios/www\" folder and all its contents to the \"MyApp\" app's \"Production\" deployment, targeting only the 1.0.3 binary version")
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "The deployment to publish the update to", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" });
@@ -297,7 +297,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         addCommonConfiguration(yargs);
     })
     .command("release-react", "Release a new version of your React Native app to a specific deployment", (yargs: yargs.Argv) => {
-        yargs.usage(USAGE_PREFIX + " release-react <appName> <platform> [--deploymentName <deploymentName>] [--description <description>] [--entryFile <entryFile>] [--mandatory] [--sourcemapOutput <sourcemapOutput>]")
+        yargs.usage(USAGE_PREFIX + " release-react <appName> <platform> [--deploymentName <deploymentName>] [--description <description>] [--entryFile <entryFile>] [--mandatory] [--sourcemapOutput <sourcemapOutput>] [--targetBinaryRange <targetBinaryRange>]")
             .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
             .example("release-react MyApp ios", "Release the React Native iOS project in the current working directory to the \"MyApp\" app's \"Staging\" deployment")
             .example("release-react MyApp android -d Production", "Release the React Native Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment")
@@ -306,7 +306,8 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
             .option("entryFile", { alias: "e", default: null, demand: false, description: "The path to the root JS file. If unspecified, \"index.<platform>.js\" and then \"index.js\" will be tried and used if they exist.", type: "string" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" })
-            .option("sourcemapOutput", { alias: "s", default: null, demand: false, description: "The path to where the sourcemap for the resulting bundle should be stored. If unspecified, sourcemaps will not be generated.", type: "string" });
+            .option("sourcemapOutput", { alias: "s", default: null, demand: false, description: "The path to where the sourcemap for the resulting bundle should be stored. If unspecified, sourcemaps will not be generated.", type: "string" })
+            .option("targetBinaryRange", { alias: "t", default: null, demand: false, description: "The semver range expression spanning all the binary app store versions that should get this update. If omitted, the update will default to target only the same version as the current binary version specified in \"Info.plist\" (iOS) or \"build.gradle\" (Android)", type: "string" });
 
         addCommonConfiguration(yargs);
     })
@@ -326,7 +327,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
     .check((argv: any, aliases: { [aliases: string]: string }): any => isValidCommandCategory)  // Report unrecognized, non-hyphenated command category.
     .fail((msg: string) => showHelp(/*showRootDescription*/ true))  // Suppress the default error message.
     .argv;
-
+    
 function createCommand(): cli.ICommand {
     var cmd: cli.ICommand;
 
@@ -560,7 +561,8 @@ function createCommand(): cli.ICommand {
 
                     releaseCommand.appName = arg1;
                     releaseCommand.package = arg2;
-                    releaseCommand.appStoreVersion = arg3;
+                    // Floating points e.g. "1.2" gets parsed as a number by default, but semver requires strings.
+                    releaseCommand.appStoreVersion = arg3.toString();
                     releaseCommand.deploymentName = argv["deploymentName"];
                     releaseCommand.description = argv["description"] ? backslash(argv["description"]) : "";
                     releaseCommand.mandatory = argv["mandatory"];
@@ -582,6 +584,7 @@ function createCommand(): cli.ICommand {
                     releaseReactCommand.entryFile = argv["entryFile"];
                     releaseReactCommand.mandatory = argv["mandatory"];
                     releaseReactCommand.sourcemapOutput = argv["sourcemapOutput"];
+                    releaseReactCommand.appStoreVersion = argv["targetBinaryRange"];
                 }
                 break;
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -284,7 +284,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         addCommonConfiguration(yargs);
     })
     .command("release", "Release a new version of your app to a specific deployment", (yargs: yargs.Argv) => {
-        yargs.usage(USAGE_PREFIX + " release <appName> <updateContentsPath> <targetBinaryRange> [--deploymentName <deploymentName>] [--description <description>] [--mandatory]")
+        yargs.usage(USAGE_PREFIX + " release <appName> <updateContentsPath> <targetBinaryVersion> [--deploymentName <deploymentName>] [--description <description>] [--mandatory]")
             .demand(/*count*/ 4, /*max*/ 4)  // Require exactly four non-option arguments.
             .example("release MyApp app.js \"*\"", "Release the \"app.js\" file to the \"MyApp\" app's \"Staging\" deployment, targeting any binary version using the \"*\" wildcard range syntax.")
             .example("release MyApp ./platforms/ios/www 1.0.3 -d Production", "Release the \"./platforms/ios/www\" folder and all its contents to the \"MyApp\" app's \"Production\" deployment, targeting only the 1.0.3 binary version")
@@ -295,7 +295,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         addCommonConfiguration(yargs);
     })
     .command("release-react", "Release a new version of your React Native app to a specific deployment", (yargs: yargs.Argv) => {
-        yargs.usage(USAGE_PREFIX + " release-react <appName> <platform> [--deploymentName <deploymentName>] [--description <description>] [--entryFile <entryFile>] [--mandatory] [--sourcemapOutput <sourcemapOutput>] [--targetBinaryRange <targetBinaryRange>]")
+        yargs.usage(USAGE_PREFIX + " release-react <appName> <platform> [--deploymentName <deploymentName>] [--description <description>] [--entryFile <entryFile>] [--mandatory] [--sourcemapOutput <sourcemapOutput>] [--targetBinaryVersion <targetBinaryVersion>]")
             .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
             .example("release-react MyApp ios", "Release the React Native iOS project in the current working directory to the \"MyApp\" app's \"Staging\" deployment")
             .example("release-react MyApp android -d Production", "Release the React Native Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment")
@@ -305,7 +305,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("entryFile", { alias: "e", default: null, demand: false, description: "The path to the root JS file. If unspecified, \"index.<platform>.js\" and then \"index.js\" will be tried and used if they exist.", type: "string" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" })
             .option("sourcemapOutput", { alias: "s", default: null, demand: false, description: "The path to where the sourcemap for the resulting bundle should be stored. If unspecified, sourcemaps will not be generated.", type: "string" })
-            .option("targetBinaryRange", { alias: "t", default: null, demand: false, description: "The semver range expression spanning all the binary app store versions that should get this update. If omitted, the update will default to target only the same version as the current binary version specified in \"Info.plist\" (iOS) or \"build.gradle\" (Android)", type: "string" });
+            .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "The semver range expression spanning all the binary app store versions that should get this update. If omitted, the update will default to target only the same version as the current binary version specified in \"Info.plist\" (iOS) or \"build.gradle\" (Android)", type: "string" });
 
         addCommonConfiguration(yargs);
     })
@@ -578,7 +578,7 @@ function createCommand(): cli.ICommand {
                     releaseReactCommand.entryFile = argv["entryFile"];
                     releaseReactCommand.mandatory = argv["mandatory"];
                     releaseReactCommand.sourcemapOutput = argv["sourcemapOutput"];
-                    releaseReactCommand.appStoreVersion = argv["targetBinaryRange"];
+                    releaseReactCommand.appStoreVersion = argv["targetBinaryVersion"];
                 }
                 break;
 

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -187,7 +187,7 @@ describe("CLI", () => {
     var sandbox: Sinon.SinonSandbox;
     var spawn: Sinon.SinonStub;
     var wasConfirmed = true;
-    const RELEASE_FAILED_ERROR_MESSAGE: string = "It is unnecessary to package releases in a .zip or binary file. Please specify the direct path to the update content's directory (e.g. /platforms/ios/www) or file (e.g. main.jsbundle).";
+    const INVALID_RELEASE_FILE_ERROR_MESSAGE: string = "It is unnecessary to package releases in a .zip or binary file. Please specify the direct path to the update content's directory (e.g. /platforms/ios/www) or file (e.g. main.jsbundle).";
 
     beforeEach((): void => {
         wasConfirmed = true;
@@ -684,6 +684,20 @@ describe("CLI", () => {
             });
     });
 
+    it("release doesn't allow non valid semver ranges", (done: MochaDone): void => {
+        var command: cli.IReleaseCommand = {
+            type: cli.CommandType.release,
+            appName: "a",
+            deploymentName: "Staging",
+            description: "test releasing zip file",
+            mandatory: false,
+            appStoreVersion: "not semver",
+            package: "./resources"
+        };
+
+        releaseHelperFunction(command, done, "Please use a semver-compliant target binary version range, for example \"^1.0.3\".");
+    });
+
     it("release doesn't allow releasing .zip file", (done: MochaDone): void => {
         var command: cli.IReleaseCommand = {
             type: cli.CommandType.release,
@@ -695,7 +709,7 @@ describe("CLI", () => {
             package: "/fake/path/test/file.zip"
         };
 
-        releaseHelperFunction(command, done);
+        releaseHelperFunction(command, done, INVALID_RELEASE_FILE_ERROR_MESSAGE);
     });
 
     it("release doesn't allow releasing .ipa file", (done: MochaDone): void => {
@@ -709,7 +723,7 @@ describe("CLI", () => {
             package: "/fake/path/test/file.ipa"
         };
 
-        releaseHelperFunction(command, done);
+        releaseHelperFunction(command, done, INVALID_RELEASE_FILE_ERROR_MESSAGE);
     });
 
     it("release doesn't allow releasing .apk file", (done: MochaDone): void => {
@@ -723,13 +737,14 @@ describe("CLI", () => {
             package: "/fake/path/test/file.apk"
         };
 
-        releaseHelperFunction(command, done);
+        releaseHelperFunction(command, done, INVALID_RELEASE_FILE_ERROR_MESSAGE);
     });
 
     it("release-react fails if CWD does not contain package.json", (done: MochaDone): void => {
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
             appName: "a",
+            appStoreVersion: null,
             deploymentName: "Staging",
             description: "Test invalid folder",
             mandatory: false,
@@ -757,6 +772,7 @@ describe("CLI", () => {
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
             appName: "a",
+            appStoreVersion: null,
             deploymentName: "Staging",
             description: "Test invalid entryFile",
             entryFile: "doesntexist.js",
@@ -787,6 +803,7 @@ describe("CLI", () => {
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
             appName: "a",
+            appStoreVersion: null,
             deploymentName: "Staging",
             description: "Test invalid platform",
             mandatory: false,
@@ -812,11 +829,45 @@ describe("CLI", () => {
             .done();
     });
 
+    it("release-react fails if targetBinaryRange is not a valid semver range expression", (done: MochaDone): void => {
+        var bundleName = "bundle.js";
+        var command: cli.IReleaseReactCommand = {
+            type: cli.CommandType.releaseReact,
+            appName: "a",
+            appStoreVersion: "notsemver",
+            bundleName: bundleName,
+            deploymentName: "Staging",
+            description: "Test uses targetBinaryRange",
+            mandatory: false,
+            platform: "android",
+            sourcemapOutput: "index.android.js.map"
+        };
+
+        ensureInTestAppDirectory();
+
+        var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release", () => { return Q(<void>null) });
+        var releaseReact: Sinon.SinonSpy = sandbox.spy(cmdexec, "releaseReact");
+
+        cmdexec.execute(command)
+            .then(() => {
+                done(new Error("Did not throw error."));
+            })
+            .catch((err) => {
+                assert.equal(err.message, "Please use a semver-compliant target binary version range, for example \"^1.0.3\".");
+                sinon.assert.notCalled(release);
+                sinon.assert.threw(releaseReact, "Error");
+                sinon.assert.notCalled(spawn);
+                done();
+            })
+            .done();
+    });
+
     it("release-react defaults entry file to index.{platform}.js if not provided", (done: MochaDone): void => {
         var bundleName = "bundle.js";
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
             appName: "a",
+            appStoreVersion: null,
             bundleName: bundleName,
             deploymentName: "Staging",
             description: "Test default entry file",
@@ -852,6 +903,7 @@ describe("CLI", () => {
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
             appName: "a",
+            appStoreVersion: null,
             deploymentName: "Staging",
             description: "Test default entry file",
             mandatory: false,
@@ -886,6 +938,7 @@ describe("CLI", () => {
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
             appName: "a",
+            appStoreVersion: null,
             deploymentName: "Staging",
             description: "Test default entry file",
             mandatory: false,
@@ -921,6 +974,7 @@ describe("CLI", () => {
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
             appName: "a",
+            appStoreVersion: null,
             bundleName: bundleName,
             deploymentName: "Staging",
             description: "Test generates sourcemaps",
@@ -953,14 +1007,51 @@ describe("CLI", () => {
             .done();
     });
 
-    function releaseHelperFunction(command: cli.IReleaseCommand, done: MochaDone): void {
+    it("release-react uses specified targetBinaryRange option", (done: MochaDone): void => {
+        var bundleName = "bundle.js";
+        var command: cli.IReleaseReactCommand = {
+            type: cli.CommandType.releaseReact,
+            appName: "a",
+            appStoreVersion: ">=1.0.0 <1.0.5",
+            bundleName: bundleName,
+            deploymentName: "Staging",
+            description: "Test uses targetBinaryRange",
+            mandatory: false,
+            platform: "android",
+            sourcemapOutput: "index.android.js.map"
+        };
+
+        ensureInTestAppDirectory();
+
+        var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release", () => { return Q(<void>null) });
+
+        cmdexec.execute(command)
+            .then(() => {
+                var releaseCommand: cli.IReleaseCommand = <any>command;
+                releaseCommand.package = path.join(os.tmpdir(), "CodePush");
+                
+                sinon.assert.calledOnce(spawn);
+                var spawnCommand: string = spawn.args[0][0];
+                var spawnCommandArgs: string = spawn.args[0][1].join(" ");
+                assert.equal(spawnCommand, "node");
+                assert.equal(
+                    spawnCommandArgs,
+                    `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(os.tmpdir(), "CodePush")} --bundle-output ${path.join(os.tmpdir(), "CodePush", bundleName)} --dev false --entry-file index.android.js --platform android --sourcemap-output index.android.js.map`
+                );
+                assertJsonDescribesObject(JSON.stringify(release.args[0][0], /*replacer=*/ null, /*spacing=*/ 2), releaseCommand);
+                done();
+            })
+            .done();
+    });
+    
+    function releaseHelperFunction(command: cli.IReleaseCommand, done: MochaDone, expectedError: string): void {
         var release: Sinon.SinonSpy = sandbox.spy(cmdexec.sdk, "release");
         cmdexec.execute(command)
             .done((): void => {
                 throw "Error Expected";
             }, (error: any): void => {
                 assert (!!error);
-                assert.equal(error.message, RELEASE_FAILED_ERROR_MESSAGE);
+                assert.equal(error.message, expectedError);
                 done();
             });
     }

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -695,7 +695,7 @@ describe("CLI", () => {
             package: "./resources"
         };
 
-        releaseHelperFunction(command, done, "Please use a semver-compliant target binary version range, for example \"^1.0.3\".");
+        releaseHelperFunction(command, done, "Please use a semver-compliant target binary version range, for example \"1.0.0\", \"*\" or \"^1.2.3\".");
     });
 
     it("release doesn't allow releasing .zip file", (done: MochaDone): void => {
@@ -853,7 +853,7 @@ describe("CLI", () => {
                 done(new Error("Did not throw error."));
             })
             .catch((err) => {
-                assert.equal(err.message, "Please use a semver-compliant target binary version range, for example \"^1.0.3\".");
+                assert.equal(err.message, "Please use a semver-compliant target binary version range, for example \"1.0.0\", \"*\" or \"^1.2.3\".");
                 sinon.assert.notCalled(release);
                 sinon.assert.threw(releaseReact, "Error");
                 sinon.assert.notCalled(spawn);


### PR DESCRIPTION
Allow updates to target a range of binary versions using semver range expressions https://github.com/npm/node-semver#advanced-range-syntax. Added an extra option in the `release-react` command to allow users to override the target binary range value specified in the app metadata. Added some tests for the new changes.

Updated the docs to reflect this new behaviour. 