### PR TITLE
Expose --dev option to release-react

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -304,6 +304,7 @@ code-push release-react <appName> <platform>
 [--bundleName <bundleName>]
 [--deploymentName <deploymentName>]
 [--description <description>]
+[--development <development>]
 [--entryFile <entryFile>]
 [--mandatory]
 [--sourcemapOutput <sourcemapOutput>]
@@ -331,6 +332,10 @@ This is the same parameter as the one described in the [above section](#deployme
 ### Description parameter
 
 This is the same parameter as the one described in the [above section](#description-parameter).
+
+### Development parameter
+
+This specifies whether to generate a unminified, development JS bundle.
 
 ### Entry file parameter
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -136,6 +136,7 @@ export interface IReleaseCommand extends IReleaseBaseCommand {
 
 export interface IReleaseReactCommand extends IReleaseBaseCommand {
     bundleName?: string;
+    development?: boolean;
     entryFile?: string;
     platform: string;
     sourcemapOutput?: string;

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -983,7 +983,7 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
         // This is needed to clear the react native bundler cache:
         // https://github.com/facebook/react-native/issues/4289
         .then(() => deleteFolder(`${os.tmpdir()}/react-*`))
-        .then(() => runReactNativeBundleCommand(bundleName, entryFile, outputFolder, platform, command.sourcemapOutput))
+        .then(() => runReactNativeBundleCommand(bundleName, command.development || false, entryFile, outputFolder, platform, command.sourcemapOutput))
         .then(() => {
             log(chalk.cyan("\nReleasing update contents to CodePush:\n"));
             return release(releaseCommand);
@@ -1033,12 +1033,12 @@ function requestAccessKey(): Promise<string> {
     });
 }
 
-export var runReactNativeBundleCommand = (bundleName: string, entryFile: string, outputFolder: string, platform: string, sourcemapOutput: string): Promise<void> => {
+export var runReactNativeBundleCommand = (bundleName: string, development: boolean, entryFile: string, outputFolder: string, platform: string, sourcemapOutput: string): Promise<void> => {
     var reactNativeBundleArgs = [
         path.join("node_modules", "react-native", "local-cli", "cli.js"), "bundle",
         "--assets-dest", outputFolder,
         "--bundle-output", path.join(outputFolder, bundleName),
-        "--dev", false,
+        "--dev", development,
         "--entry-file", entryFile,
         "--platform", platform,
     ];

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -302,6 +302,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("bundleName", { alias: "b", default: null, demand: false, description: "The name of the output JS bundle. If omitted, the standard bundle name will be used for the specified platform: \"main.jsbundle\" (iOS) and \"index.android.bundle\" (Android)", type: "string" })
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "The deployment to publish the update to", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
+            .option("development", { alias: "dev", default: false, demand: false, description: "Whether to generate a unminified, development JS bundle.", type: "boolean" })
             .option("entryFile", { alias: "e", default: null, demand: false, description: "The path to the root JS file. If unspecified, \"index.<platform>.js\" and then \"index.js\" will be tried and used if they exist.", type: "string" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" })
             .option("sourcemapOutput", { alias: "s", default: null, demand: false, description: "The path to where the sourcemap for the resulting bundle should be stored. If unspecified, sourcemaps will not be generated.", type: "string" })
@@ -575,6 +576,7 @@ function createCommand(): cli.ICommand {
                     releaseReactCommand.bundleName = argv["bundleName"];
                     releaseReactCommand.deploymentName = argv["deploymentName"];
                     releaseReactCommand.description = argv["description"] ? backslash(argv["description"]) : "";
+                    releaseReactCommand.development = argv["development"];
                     releaseReactCommand.entryFile = argv["entryFile"];
                     releaseReactCommand.mandatory = argv["mandatory"];
                     releaseReactCommand.sourcemapOutput = argv["sourcemapOutput"];

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -978,7 +978,7 @@ describe("CLI", () => {
             bundleName: bundleName,
             deploymentName: "Staging",
             development: true,
-            description: "Test generates sourcemaps",
+            description: "Test generates dev bundle",
             mandatory: false,
             platform: "android",
             sourcemapOutput: "index.android.js.map"

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -969,6 +969,45 @@ describe("CLI", () => {
             .done();
     });
     
+    it("release-react generates dev bundle", (done: MochaDone): void => {
+        var bundleName = "bundle.js";
+        var command: cli.IReleaseReactCommand = {
+            type: cli.CommandType.releaseReact,
+            appName: "a",
+            appStoreVersion: null,
+            bundleName: bundleName,
+            deploymentName: "Staging",
+            development: true,
+            description: "Test generates sourcemaps",
+            mandatory: false,
+            platform: "android",
+            sourcemapOutput: "index.android.js.map"
+        };
+
+        ensureInTestAppDirectory();
+
+        var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release", () => { return Q(<void>null) });
+
+        cmdexec.execute(command)
+            .then(() => {
+                var releaseCommand: cli.IReleaseCommand = <any>command;
+                releaseCommand.package = path.join(os.tmpdir(), "CodePush");
+                releaseCommand.appStoreVersion = "1.2.3";
+
+                sinon.assert.calledOnce(spawn);
+                var spawnCommand: string = spawn.args[0][0];
+                var spawnCommandArgs: string = spawn.args[0][1].join(" ");
+                assert.equal(spawnCommand, "node");
+                assert.equal(
+                    spawnCommandArgs,
+                    `${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(os.tmpdir(), "CodePush")} --bundle-output ${path.join(os.tmpdir(), "CodePush", bundleName)} --dev true --entry-file index.android.js --platform android --sourcemap-output index.android.js.map`
+                );
+                assertJsonDescribesObject(JSON.stringify(release.args[0][0], /*replacer=*/ null, /*spacing=*/ 2), releaseCommand);
+                done();
+            })
+            .done();
+    });
+    
     it("release-react generates sourcemaps", (done: MochaDone): void => {
         var bundleName = "bundle.js";
         var command: cli.IReleaseReactCommand = {


### PR DESCRIPTION
Just a super quick, 5min change that exposes the --dev option to the release-react command since I figured it would be useful for my demo.