### PR TITLE
Change the SDK's addAccessKey() method to be more consumable

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -96,8 +96,7 @@ export var confirm = (): Promise<boolean> => {
 }
 
 function accessKeyAdd(command: cli.IAccessKeyAddCommand): Promise<void> {
-    var hostname: string = os.hostname();
-    return sdk.addAccessKey(hostname, command.description)
+    return sdk.addAccessKey(command.description)
         .then((accessKey: AccessKey) => {
             log("Successfully created a new access key" + (command.description ? (" \"" + command.description + "\"") : "") + ": " + accessKey.name);
         });
@@ -844,8 +843,8 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
 export var release = (command: cli.IReleaseCommand): Promise<void> => {
     if (isBinaryOrZip(command.package)) {
         throw new Error("It is unnecessary to package releases in a .zip or binary file. Please specify the direct path to the update content's directory (e.g. /platforms/ios/www) or file (e.g. main.jsbundle).");
-    } 
-    
+    }
+
     throwForInvalidSemverRange(command.appStoreVersion);
     var filePath: string = command.package;
     var getPackageFilePromise: Promise<IPackageFile>;
@@ -968,11 +967,11 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
             throw new Error(`Entry file "${entryFile}" does not exist.`);
         }
     }
-    
+
     if (command.appStoreVersion) {
         throwForInvalidSemverRange(command.appStoreVersion);
     }
-    
+
     var appVersionPromise: Promise<string> = command.appStoreVersion
         ? Q(command.appStoreVersion)
         : getReactNativeProjectAppVersion(platform, projectName);
@@ -1100,7 +1099,7 @@ function throwForInvalidSemverRange(semverRange: string): void {
     if (semver.validRange(semverRange) === null) {
         throw new Error("Please use a semver-compliant target binary version range, for example \"1.0.0\", \"*\" or \"^1.2.3\".");
     }
-} 
+}
 
 function throwForInvalidOutputFormat(format: string): void {
     switch (format) {

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -26,7 +26,7 @@ export class SdkStub {
         });
     }
 
-    public addAccessKey(machine: string, description?: string): Promise<codePush.AccessKey> {
+    public addAccessKey(description: string): Promise<codePush.AccessKey> {
         return Q(<codePush.AccessKey>{
             name: "key123",
             createdTime: new Date().getTime(),

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -1,8 +1,10 @@
 import * as base64 from "base-64";
-import Q = require("q");
 import crypto = require("crypto");
-import Promise = Q.Promise;
+import * as os from "os";
+import Q = require("q");
 import superagent = require("superagent");
+
+import Promise = Q.Promise;
 
 import { AccessKey, Account, App, CodePushError, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Headers, Package, UpdateMetrics } from "./types";
 
@@ -88,8 +90,9 @@ class AccountManager {
         });
     }
 
-    public addAccessKey(machine: string, description?: string): Promise<AccessKey> {
-        var accessKeyRequest: AccessKey = { createdBy: machine, description: description };
+    public addAccessKey(description: string): Promise<AccessKey> {
+        var hostname: string = os.hostname();
+        var accessKeyRequest: AccessKey = { createdBy: hostname, description: description };
         return this.post(urlEncode `/accessKeys/`, JSON.stringify(accessKeyRequest), /*expectResponseBody=*/ true)
             .then((response: JsonResponse) => response.body.accessKey);
     }

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -91,6 +91,10 @@ class AccountManager {
     }
 
     public addAccessKey(description: string): Promise<AccessKey> {
+        if (!description) {
+            throw new Error("A description must be specified when adding an access key.");
+        }
+
         var hostname: string = os.hostname();
         var accessKeyRequest: AccessKey = { createdBy: hostname, description: description };
         return this.post(urlEncode `/accessKeys/`, JSON.stringify(accessKeyRequest), /*expectResponseBody=*/ true)


### PR DESCRIPTION
Infer the hostname internally within the method, and make the description field compulsory (in TypeScript at least).