### PR TITLE
Add release-cordova

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -353,6 +353,43 @@ This specifies the relative path to where the sourcemap file for resulting updat
 
 This is the same parameter as the one described in the [above section](#target-binary-version-parameter). If left unspecified, the command defaults to targeting only the specified version in the project's metadata (`Info.plist` if this update is for iOS clients, and `build.gradle` for Android clients).
 
+## Releasing updates to a Cordova app
+After configuring your Cordova app to query for updates against the CodePush service--using your desired deployment--you can begin pushing updates to it using the following command:
+
+```
+code-push release-cordova <appName> <platform>
+[--deploymentName <deploymentName>]
+[--description <description>]
+[--mandatory]
+[--binaryVersion <targetBinaryVersion>]
+```
+This `release-cordova` command does two things in addition to running the vanilla `release` command described in the [Releasing App Updates](#releasing-app-updates) section:
+
+1. It runs the [`cordova prepare` command](#update-contents-parameter) to generate the update contents for the specified platform
+2. It infers the [`targetBinaryVersion` of this release](#target-binary-range-parameter) by reading the version in the &lt;widget version&gt; in config.xml, and defaults to target only the specified version.
+
+It then calls the vanilla `release` command by supplying the values for the required parameters using the above information. Doing this helps you avoid the manual step of generating the update contents yourself using the `cordova prepare` command and also avoid common pitfalls such as supplying an invalid `targetBinaryVersion` parameter.
+
+### Platform parameter**
+
+This specifies which platform the current update is targeting, and can be either `ios` or `android` (case-insensitive).
+
+### Deployment name parameter
+
+This is the same parameter as the one described in the [above section](#deployment-name-parameter).
+
+### Description parameter
+
+This is the same parameter as the one described in the [above section](#description-parameter).
+
+### Mandatory parameter
+
+This is the same parameter as the one described in the [above section](#mandatory-parameter).
+
+### Target binary version parameter
+
+This is the same parameter as the one described in the [above section](#target-binary-version-parameter). If left unspecified, the command defaults to targeting only the specified version in the project's metadata (`Info.plist` if this update is for iOS clients, and `build.gradle` for Android clients).
+
 ## Promoting updates across deployments
 
 Once you've tested an update against a specific deployment (e.g. `Staging`), and you want to promote it "downstream" (e.g. dev->staging, staging->production), you can simply use the following command to copy the release from one deployment to another:

--- a/cli/README.md
+++ b/cli/README.md
@@ -299,7 +299,7 @@ If you never release an update that is marked as mandatory, then the above behav
 
 After configuring your React Native app to query for updates against the CodePush service--using your desired deployment--you can begin pushing updates to it using the following command:
 
-```
+```shell
 code-push release-react <appName> <platform>
 [--bundleName <bundleName>]
 [--deploymentName <deploymentName>]
@@ -308,9 +308,10 @@ code-push release-react <appName> <platform>
 [--entryFile <entryFile>]
 [--mandatory]
 [--sourcemapOutput <sourcemapOutput>]
+[--targetBinaryVersion <targetBinaryVersion>]
 ```
 
-This `release-react` command does two things in addition to running the vanilla `release` command described in the [previous section](#releasing-app-updates):
+The `release-react` command does two things in addition to running the vanilla `release` command described in the [previous section](#releasing-app-updates):
 
 1. It runs the [`react-native bundle` command](#update-contents-parameter) to generate the update contents in a temporary folder
 2. It infers the [`targetBinaryVersion` of this release](#target-binary-range-parameter) by reading the contents of the project's metadata (`Info.plist` if this update is for iOS clients, and `build.gradle` for Android clients), and defaults to target only the specified version in the metadata.
@@ -356,21 +357,21 @@ This is the same parameter as the one described in the [above section](#target-b
 ## Releasing updates to a Cordova app
 After configuring your Cordova app to query for updates against the CodePush service--using your desired deployment--you can begin pushing updates to it using the following command:
 
-```
+```shell
 code-push release-cordova <appName> <platform>
 [--deploymentName <deploymentName>]
 [--description <description>]
 [--mandatory]
-[--binaryVersion <targetBinaryVersion>]
+[--targetBinaryVersion <targetBinaryVersion>]
 ```
-This `release-cordova` command does two things in addition to running the vanilla `release` command described in the [Releasing App Updates](#releasing-app-updates) section:
+The `release-cordova` command does two things in addition to running the vanilla `release` command described in the [Releasing App Updates](#releasing-app-updates) section:
 
-1. It runs the [`cordova prepare` command](#update-contents-parameter) to generate the update contents for the specified platform
-2. It infers the [`targetBinaryVersion` of this release](#target-binary-range-parameter) by reading the version in the &lt;widget version&gt; in config.xml, and defaults to target only the specified version.
+1. It [updates the contents](#update-contents-parameter) of the package by calling `cordova prepare` for the specified platform
+2. It infers the [`targetBinaryVersion` of this release](#target-binary-range-parameter) by reading the version in the `<widget version>` in config.xml, and defaults to target only the specified version.
 
 It then calls the vanilla `release` command by supplying the values for the required parameters using the above information. Doing this helps you avoid the manual step of generating the update contents yourself using the `cordova prepare` command and also avoid common pitfalls such as supplying an invalid `targetBinaryVersion` parameter.
 
-### Platform parameter**
+### Platform parameter
 
 This specifies which platform the current update is targeting, and can be either `ios` or `android` (case-insensitive).
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -135,7 +135,7 @@ export interface IReleaseCommand extends IReleaseBaseCommand {
     package: string;
 }
 
-export interface IReleaseCordovaCommand extends IReleaseCommand {
+export interface IReleaseCordovaCommand extends IReleaseBaseCommand {
     platform: string;
 }
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -21,6 +21,7 @@
     promote,
     register,
     release,
+    releaseCordova,
     releaseReact,
     rollback
 }
@@ -132,6 +133,15 @@ export interface IReleaseBaseCommand extends ICommand {
 
 export interface IReleaseCommand extends IReleaseBaseCommand {
     package: string;
+}
+
+export interface IReleaseCordovaCommand extends ICommand {
+    appName?: string;
+    appStoreVersion?: string;
+    deploymentName: string;
+    description?: string;
+    mandatory: boolean;
+    platform: string;
 }
 
 export interface IReleaseReactCommand extends IReleaseBaseCommand {

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -135,12 +135,7 @@ export interface IReleaseCommand extends IReleaseBaseCommand {
     package: string;
 }
 
-export interface IReleaseCordovaCommand extends ICommand {
-    appName?: string;
-    appStoreVersion?: string;
-    deploymentName: string;
-    description?: string;
-    mandatory: boolean;
+export interface IReleaseCordovaCommand extends IReleaseCommand {
     platform: string;
 }
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -43,6 +43,7 @@
     "slash": "1.0.0",
     "update-notifier": "^0.5.0",
     "wordwrap": "1.0.0",
+    "xml2js": "^0.4.16",
     "yargs": "^3.15.0",
     "yazl": "2.2.2"
   }

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -938,12 +938,12 @@ export var releaseCordova = (command: cli.IReleaseCordovaCommand): Promise<void>
     }
 
     try {
-        var tempPrepareFile = path.join(platformCordova, "tempPrepare.js");
+        var tempPrepareFile: string = path.join(platformCordova, "tempPrepare.js");
 
         var tempPrepareContents = "var fs= require('fs'); var path = require('path'); var ConfigParser = require('cordova-common').ConfigParser; var Api = require('./Api'); var projRoot = path.join(process.cwd(), '../../..'); var project = {projectConfig: new ConfigParser(path.join(projRoot, 'config.xml')),root: projRoot,locations: {www: path.join(projRoot, 'www')}}; var preparer = new Api(); preparer.prepare(project);"
         fs.writeFileSync(tempPrepareFile, tempPrepareContents);
 
-        var prepareOptions = { cwd: platformCordova };
+        var prepareOptions: any = { cwd: platformCordova };
         var prepareProcess = spawn("node", ["tempPrepare.js"], prepareOptions);
 
         preparePromise = Promise<void>((resolve, reject, notify) => {
@@ -956,6 +956,7 @@ export var releaseCordova = (command: cli.IReleaseCordovaCommand): Promise<void>
             });
 
             prepareProcess.on("close", (exitCode: number) => {
+                fs.unlinkSync(tempPrepareFile);
                 if (exitCode) {
                     reject(new Error(`"node" command exited with code ${exitCode}.`));
                 }

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -940,14 +940,14 @@ export var releaseCordova = (command: cli.IReleaseCordovaCommand): Promise<void>
     }
 
     var prepareScript = `
-        var path = require('path');
-        var ConfigParser = require('cordova-common').ConfigParser;
-        var Api = require('./Api');
+        var path = require("path");
+        var ConfigParser = require("cordova-common").ConfigParser;
+        var Api = require("./Api");
         var project = {
-            projectConfig: new ConfigParser(path.join("${projectRoot}", 'config.xml')),
+            projectConfig: new ConfigParser(path.join("${projectRoot}", "config.xml")),
             root: "${projectRoot}",
             locations: {
-                www: path.join("${projectRoot}", 'www')
+                www: path.join("${projectRoot}", "www")
             }
         };
         var preparer = new Api();

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -294,6 +294,19 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
 
         addCommonConfiguration(yargs);
     })
+    .command("release-cordova", "Release a new version of your Cordova app to a specific deployment", (yargs: yargs.Argv) => {
+        yargs.usage(USAGE_PREFIX + " release-cordova <platform> [--appName <appName>] [--deploymentName <deploymentName>] [--description <description>] [--mandatory] [--targetBinaryVersion <targetBinaryVersion>]")
+            .demand(/*count*/ 2, /*max*/ 2)  // Require exactly two non-option arguments.
+            .example("release-cordova ios", "Release the Cordova iOS project in the current working directory to the app's \"Staging\" deployment. Name pulled from config.xml")
+            .example("release-cordova android -a MyApp -d Production", "Release the Cordova Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment")
+            .option("appName", { alias: "a", default: null, demand: false, description: "The name of the app to deploy to. Defaults to the name specified in the config.xml", type: "string"})
+            .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "The deployment to publish the update to", type: "string" })
+            .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
+            .option("mandatory", { alias: "m", default: false, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" })
+            .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "The semver range expression spanning all the binary app store versions that should get this update. If omitted, the update will default to target only the same version as the current binary version specified in config.xml", type: "string" });
+
+        addCommonConfiguration(yargs);
+    })
     .command("release-react", "Release a new version of your React Native app to a specific deployment", (yargs: yargs.Argv) => {
         yargs.usage(USAGE_PREFIX + " release-react <appName> <platform> [--deploymentName <deploymentName>] [--description <description>] [--entryFile <entryFile>] [--mandatory] [--sourcemapOutput <sourcemapOutput>] [--targetBinaryVersion <targetBinaryVersion>]")
             .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
@@ -561,6 +574,22 @@ function createCommand(): cli.ICommand {
                     releaseCommand.deploymentName = argv["deploymentName"];
                     releaseCommand.description = argv["description"] ? backslash(argv["description"]) : "";
                     releaseCommand.mandatory = argv["mandatory"];
+                }
+                break;
+                
+            case "release-cordova":
+                if (arg1) {
+                    cmd = { type: cli.CommandType.releaseCordova };
+
+                    var releaseCordovaCommand = <cli.IReleaseCordovaCommand>cmd;
+
+                    releaseCordovaCommand.platform = arg1;
+
+                    releaseCordovaCommand.appName = argv["appName"];
+                    releaseCordovaCommand.deploymentName = argv["deploymentName"];
+                    releaseCordovaCommand.description = argv["description"] ? backslash(argv["description"]) : "";
+                    releaseCordovaCommand.mandatory = argv["mandatory"];
+                    releaseCordovaCommand.appStoreVersion = argv["targetBinaryVersion"];
                 }
                 break;
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -295,11 +295,10 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         addCommonConfiguration(yargs);
     })
     .command("release-cordova", "Release a new version of your Cordova app to a specific deployment", (yargs: yargs.Argv) => {
-        yargs.usage(USAGE_PREFIX + " release-cordova <platform> [--appName <appName>] [--deploymentName <deploymentName>] [--description <description>] [--mandatory] [--targetBinaryVersion <targetBinaryVersion>]")
-            .demand(/*count*/ 2, /*max*/ 2)  // Require exactly two non-option arguments.
-            .example("release-cordova ios", "Release the Cordova iOS project in the current working directory to the app's \"Staging\" deployment. Name pulled from config.xml")
-            .example("release-cordova android -a MyApp -d Production", "Release the Cordova Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment")
-            .option("appName", { alias: "a", default: null, demand: false, description: "The name of the app to deploy to. Defaults to the name specified in the config.xml", type: "string"})
+        yargs.usage(USAGE_PREFIX + " release-cordova <appName> <platform> [--deploymentName <deploymentName>] [--description <description>] [--mandatory] [--targetBinaryVersion <targetBinaryVersion>]")
+            .demand(/*count*/ 3, /*max*/ 3)  // Require exactly two non-option arguments.
+            .example("release-cordova MyApp ios", "Release the Cordova iOS project in the current working directory to the \"MyApp\" app's \"Staging\" deployment")
+            .example("release-cordova MyApp android -d Production", "Release the Cordova Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment")
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "The deployment to publish the update to", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" })
@@ -578,14 +577,14 @@ function createCommand(): cli.ICommand {
                 break;
                 
             case "release-cordova":
-                if (arg1) {
+                if (arg1 && arg2) {
                     cmd = { type: cli.CommandType.releaseCordova };
 
                     var releaseCordovaCommand = <cli.IReleaseCordovaCommand>cmd;
 
-                    releaseCordovaCommand.platform = arg1;
+                    releaseCordovaCommand.appName = arg1;
+                    releaseCordovaCommand.platform = arg2;
 
-                    releaseCordovaCommand.appName = argv["appName"];
                     releaseCordovaCommand.deploymentName = argv["deploymentName"];
                     releaseCordovaCommand.description = argv["description"] ? backslash(argv["description"]) : "";
                     releaseCordovaCommand.mandatory = argv["mandatory"];

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -296,7 +296,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
     })
     .command("release-cordova", "Release a new version of your Cordova app to a specific deployment", (yargs: yargs.Argv) => {
         yargs.usage(USAGE_PREFIX + " release-cordova <appName> <platform> [--deploymentName <deploymentName>] [--description <description>] [--mandatory] [--targetBinaryVersion <targetBinaryVersion>]")
-            .demand(/*count*/ 3, /*max*/ 3)  // Require exactly two non-option arguments.
+            .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
             .example("release-cordova MyApp ios", "Release the Cordova iOS project in the current working directory to the \"MyApp\" app's \"Staging\" deployment")
             .example("release-cordova MyApp android -d Production", "Release the Cordova Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment")
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "The deployment to publish the update to", type: "string" })

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -467,10 +467,10 @@ describe("CLI", () => {
                 var actual: string = log.args[0][0];
                 var expected = {
                     "collaborators":
-                        {
-                            "a@a.com": { permission: "Owner", isCurrentAccount: true },
-                            "b@b.com": { permission: "Collaborator", isCurrentAccount: false }
-                        }
+                    {
+                        "a@a.com": { permission: "Owner", isCurrentAccount: true },
+                        "b@b.com": { permission: "Collaborator", isCurrentAccount: false }
+                    }
                 };
 
                 assertJsonDescribesObject(actual, expected);
@@ -740,6 +740,178 @@ describe("CLI", () => {
         releaseHelperFunction(command, done, INVALID_RELEASE_FILE_ERROR_MESSAGE);
     });
 
+    it("release-cordova fails if Cordova project cannot be prepared", (done: MochaDone): void => {
+        var command: cli.IReleaseCordovaCommand = {
+            type: cli.CommandType.releaseCordova,
+            appName: "a",
+            appStoreVersion: null,
+            deploymentName: "Staging",
+            description: "Test invalid project",
+            mandatory: false,
+            platform: "ios"
+        };
+
+
+        var spawnSync: Sinon.SinonStub = sandbox.stub(cmdexec, "spawnSync", (command: string, commandArgs: string[], options: any) => { return { error: new Error("Failed Prepare") }; });
+        var release: Sinon.SinonSpy = sandbox.spy(cmdexec, "release");
+        var releaseCordova: Sinon.SinonSpy = sandbox.spy(cmdexec, "releaseCordova");
+
+        cmdexec.execute(command)
+            .then(() => {
+                done(new Error("Did not throw error."));
+            })
+            .catch((err) => {
+                assert.equal(err.message, `Unable to prepare project. Please ensure that this is a Cordova project and that platform "${command.platform}" was added with "cordova platform add ${command.platform}"`);
+                sinon.assert.notCalled(release);
+                sinon.assert.threw(releaseCordova, "Error");
+                done();
+            })
+            .done();
+    });
+
+    it("release-cordova fails if CWD does not contain config.xml", (done: MochaDone): void => {
+        var command: cli.IReleaseCordovaCommand = {
+            type: cli.CommandType.releaseCordova,
+            appName: "a",
+            appStoreVersion: null,
+            deploymentName: "Staging",
+            description: "Test missing config.xml",
+            mandatory: false,
+            platform: "ios"
+        };
+
+        var spawnSync: Sinon.SinonStub = sandbox.stub(cmdexec, "spawnSync", (command: string, commandArgs: string[], options: any) => { return {}; });
+        var release: Sinon.SinonSpy = sandbox.spy(cmdexec, "release");
+        var releaseCordova: Sinon.SinonSpy = sandbox.spy(cmdexec, "releaseCordova");
+
+        cmdexec.execute(command)
+            .then(() => {
+                done(new Error("Did not throw error."));
+            })
+            .catch((err) => {
+                assert.equal(err.message, `Unable to find or read "config.xml" in the CWD. The "release-cordova" command must be executed in a Cordova project folder.`);
+                sinon.assert.notCalled(release);
+                sinon.assert.threw(releaseCordova, "Error");
+                sinon.assert.calledOnce(spawnSync);
+                done();
+            })
+            .done();
+    });
+
+    it("release-cordova fails if platform is invalid", (done: MochaDone): void => {
+        var command: cli.IReleaseCordovaCommand = {
+            type: cli.CommandType.releaseCordova,
+            appName: "a",
+            appStoreVersion: null,
+            deploymentName: "Staging",
+            description: "Test invalid platform",
+            mandatory: false,
+            platform: "blackberry",
+        };
+
+        var release: Sinon.SinonSpy = sandbox.spy(cmdexec, "release");
+        var releaseCordova: Sinon.SinonSpy = sandbox.spy(cmdexec, "releaseCordova");
+
+        cmdexec.execute(command)
+            .then(() => {
+                done(new Error("Did not throw error."));
+            })
+            .catch((err) => {
+                assert.equal(err.message, "Platform must be either \"ios\" or \"android\".");
+                sinon.assert.notCalled(release);
+                sinon.assert.threw(releaseCordova, "Error");
+                sinon.assert.notCalled(spawn);
+                done();
+            })
+            .done();
+    });
+
+    it("release-cordova defaults appStoreVersion to value pulled from config.xml", (done: MochaDone): void => {
+        var command: cli.IReleaseCordovaCommand = {
+            type: cli.CommandType.releaseCordova,
+            appName: "a",
+            appStoreVersion: null,
+            deploymentName: "Staging",
+            description: "Test config.xml app version read",
+            mandatory: false,
+            platform: "ios"
+        };
+ 
+        var oldWd: string = process.cwd();
+        ensureInTestAppDirectory();
+
+        var expectedReleaseCommand: any = {
+            type: cli.CommandType.release,
+            appName: "a",
+            appStoreVersion: "0.0.1",
+            deploymentName: "Staging",
+            description: "Test config.xml app version read",
+            mandatory: false,
+            package: path.join(process.cwd(), "platforms", "ios", "www"),
+            platform: "ios"
+        }
+
+        var spawnSync: Sinon.SinonStub = sandbox.stub(cmdexec, "spawnSync", (command: string, commandArgs: string[], options: any) => { return {}; });
+        var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release");
+        var releaseCordova: Sinon.SinonSpy = sandbox.spy(cmdexec, "releaseCordova");
+
+        cmdexec.execute(command)
+            .then((compiledReleaseCommand: any) => {
+                sinon.assert.calledOnce(spawnSync);
+                sinon.assert.calledWith(release, expectedReleaseCommand);
+                done();
+            })
+            .catch((err) => {
+                done(new Error("Threw error. " + err.message));
+            })
+            .done(() => {
+                process.chdir(oldWd);
+            });
+    });
+    
+    it("release-cordova points 'package' to the built folder for android", (done: MochaDone): void => {
+        var command: cli.IReleaseCordovaCommand = {
+            type: cli.CommandType.releaseCordova,
+            appName: "a",
+            appStoreVersion: null,
+            deploymentName: "Staging",
+            description: "Test android package resolution",
+            mandatory: false,
+            platform: "android"
+        };
+ 
+        var oldWd: string = process.cwd();
+        ensureInTestAppDirectory();
+
+        var expectedReleaseCommand: any = {
+            type: cli.CommandType.release,
+            appName: "a",
+            appStoreVersion: "0.0.1",
+            deploymentName: "Staging",
+            description: "Test android package resolution",
+            mandatory: false,
+            package: path.join(process.cwd(), "platforms", "android", "assets", "www"),
+            platform: "android"
+        }
+
+        var spawnSync: Sinon.SinonStub = sandbox.stub(cmdexec, "spawnSync", (command: string, commandArgs: string[], options: any) => { return {}; });
+        var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release");
+        var releaseCordova: Sinon.SinonSpy = sandbox.spy(cmdexec, "releaseCordova");
+
+        cmdexec.execute(command)
+            .then((compiledReleaseCommand: any) => {
+                sinon.assert.calledOnce(spawnSync);
+                sinon.assert.calledWith(release, expectedReleaseCommand);
+                done();
+            })
+            .catch((err) => {
+                done(new Error("Threw error. " + err.message));
+            })
+            .done(() => {
+                process.chdir(oldWd);
+            });
+    });
+
     it("release-react fails if CWD does not contain package.json", (done: MochaDone): void => {
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
@@ -933,7 +1105,7 @@ describe("CLI", () => {
             })
             .done();
     });
-    
+
     it("release-react defaults bundle name to \"index.android.bundle\" if not provided and platform is \"android\"", (done: MochaDone): void => {
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
@@ -968,7 +1140,7 @@ describe("CLI", () => {
             })
             .done();
     });
-    
+
     it("release-react generates dev bundle", (done: MochaDone): void => {
         var bundleName = "bundle.js";
         var command: cli.IReleaseReactCommand = {
@@ -1007,7 +1179,7 @@ describe("CLI", () => {
             })
             .done();
     });
-    
+
     it("release-react generates sourcemaps", (done: MochaDone): void => {
         var bundleName = "bundle.js";
         var command: cli.IReleaseReactCommand = {
@@ -1068,7 +1240,7 @@ describe("CLI", () => {
             .then(() => {
                 var releaseCommand: cli.IReleaseCommand = <any>command;
                 releaseCommand.package = path.join(os.tmpdir(), "CodePush");
-                
+
                 sinon.assert.calledOnce(spawn);
                 var spawnCommand: string = spawn.args[0][0];
                 var spawnCommandArgs: string = spawn.args[0][1].join(" ");
@@ -1082,14 +1254,14 @@ describe("CLI", () => {
             })
             .done();
     });
-    
+
     function releaseHelperFunction(command: cli.IReleaseCommand, done: MochaDone, expectedError: string): void {
         var release: Sinon.SinonSpy = sandbox.spy(cmdexec.sdk, "release");
         cmdexec.execute(command)
             .done((): void => {
                 throw "Error Expected";
             }, (error: any): void => {
-                assert (!!error);
+                assert(!!error);
                 assert.equal(error.message, expectedError);
                 done();
             });

--- a/cli/test/resources/TestApp/config.xml
+++ b/cli/test/resources/TestApp/config.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='utf-8'?>
+<widget id="io.cordova.hellocordova" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>HelloCordova</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
+    <content src="index.html" />
+    <platform name="android">
+        <allow-intent href="market:*" />
+    </platform>
+    <platform name="ios">
+        <allow-intent href="itms:*" />
+        <allow-intent href="itms-apps:*" />
+    </platform>
+</widget>


### PR DESCRIPTION
Adds release-cordova command.

code-push release-cordova <appName> <platform>

This command will call cordova prepare and publish a release, inferring binary version from config.xml and update package from the current directory.
It will fail if the current directory does not contain a config.xml, or if the specified platform was not added to the project using the Cordova CLI.

@lostintangent @silhouettes @shishirx34 @geof90 