### PR TITLE
Gradle parsing issue

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,7 @@
     "cli-table": "^0.3.1",
     "code-push": "1.7.0-beta",
     "email-validator": "^1.0.3",
-    "gradle-to-js": "github:geof90/gradle-to-js#master",
+    "gradle-to-js": "github:geof90/gradle-to-js",
     "moment": "^2.10.6",
     "opener": "^1.4.1",
     "plist": "1.2.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,7 @@
     "cli-table": "^0.3.1",
     "code-push": "1.7.0-beta",
     "email-validator": "^1.0.3",
-    "gradle-to-js": "0.0.2",
+    "gradle-to-js": "github:geof90/gradle-to-js#master",
     "moment": "^2.10.6",
     "opener": "^1.4.1",
     "plist": "1.2.0",


### PR DESCRIPTION
The gradle-to-js npm module will parse a versionName of "1.0" as the Javascript number "1". With that, we have no way to tell whether it has a minor version or not. I forked the project and changed the parser to always return strings as the obvious but workable solution for our purposes. https://github.com/geof90/gradle-to-js/commit/ccd3362ad227203319f799dda03a6db3577c56a8