### PR TITLE
Deleting release zip on erorr

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -928,26 +928,16 @@ export var release = (command: cli.IReleaseCommand): Promise<void> => {
         lastTotalProgress = currentProgress;
     };
 
-    var deleteFileIfTemporary = (file: IPackageFile): void => {
-        if (file.isTemporary) {
-            fs.unlinkSync(filePath);
-        }
-    };
-    
     return getPackageFilePromise
         .then((file: IPackageFile): Promise<void> => {
             return sdk.release(command.appName, command.deploymentName, file.path, command.appStoreVersion, command.description, command.mandatory, uploadProgress)
                 .then((): void => {
                     log("Successfully released an update containing the \"" + command.package + "\" " + (isSingleFilePackage ? "file" : "directory") + " to the \"" + command.deploymentName + "\" deployment of the \"" + command.appName + "\" app.");
-
-                    deleteFileIfTemporary(file);
                 })
-                .catch((error): void => {
-                    deleteFileIfTemporary(file);
-                    
-                    // Rethrow the error so that the global error
-                    // handler can properly display it to the developer.
-                    throw error;
+                .finally((): void => {
+                    if (file.isTemporary) {
+                        fs.unlinkSync(filePath);
+                    }
                 });
         });
 }


### PR DESCRIPTION
This resolves #161 by ensuring that the ZIP generated by the `release` command is always deleted, regardless if the release fails (e.g. because the server rejected an identical release).