### PR TITLE
Disable releases

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -129,6 +129,7 @@ export interface IPackageInfo {
 export interface IPatchCommand extends ICommand, IPackageInfo {
     appName: string;
     deploymentName: string;
+    disabled: boolean;
     label: string;
 }
 

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -703,8 +703,13 @@ function printDeploymentHistory(command: cli.IDeploymentHistoryCommand, deployme
                 if (releaseSource) {
                     releaseTime += "\n" + chalk.magenta(`(${releaseSource})`).toString();
                 }
-
-                var row = [packageObject.label, releaseTime, packageObject.appVersion, packageObject.isMandatory ? "Yes" : "No"];
+                
+                var displayLabel: string | Chalk.ChalkChain = packageObject.label;
+                if (packageObject.isDisabled) {
+                    displayLabel = chalk.red("(x)") + packageObject.label;
+                }
+                
+                var row = [displayLabel, releaseTime, packageObject.appVersion, packageObject.isMandatory ? "Yes" : "No"];
                 if (command.displayAuthor) {
                     var releasedBy: string = packageObject.releasedBy ? packageObject.releasedBy : "";
                     if (currentUserEmail && releasedBy === currentUserEmail) {
@@ -866,7 +871,7 @@ function register(command: cli.IRegisterCommand): Promise<void> {
 }
 
 function promote(command: cli.IPromoteCommand): Promise<void> {
-    var isMandatory: boolean = getIsMandatoryValue(command.mandatory);
+    var isMandatory: boolean = getYargsBooleanOrNull(command.mandatory);
     var packageInfo: PackageInfo = {
         description: command.description,
         isMandatory: isMandatory,
@@ -880,17 +885,23 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
 }
 
 function patch(command: cli.IPatchCommand): Promise<void> {
-    var isMandatory: boolean = getIsMandatoryValue(command.mandatory);
     var packageInfo: PackageInfo = {
         description: command.description,
-        isMandatory: isMandatory,
+        isMandatory: getYargsBooleanOrNull(command.mandatory),
+        isDisabled: getYargsBooleanOrNull(command.disabled),
         rollout: command.rollout
     };
 
-    return sdk.patchRelease(command.appName, command.deploymentName, command.label, packageInfo)
-        .then((): void => {
-            log(`Successfully updated the "${command.label ? command.label : `latest`}" release of "${command.appName}" app's "${command.deploymentName}" deployment.`);
-        });
+    for (var updateProperty in packageInfo) {
+        if ((<any>packageInfo)[updateProperty] !== null) {
+            return sdk.patchRelease(command.appName, command.deploymentName, command.label, packageInfo)
+                .then((): void => {
+                    log(`Successfully updated the "${command.label ? command.label : `latest`}" release of "${command.appName}" app's "${command.deploymentName}" deployment.`);
+                });
+        }
+    }
+
+    throw new Error("At least one property must be specified.");
 }
 
 export var release = (command: cli.IReleaseCommand): Promise<void> => {
@@ -1213,9 +1224,9 @@ function isBinaryOrZip(path: string): boolean {
         || path.search(/\.ipa$/i) !== -1;
 }
 
-function getIsMandatoryValue(mandatory: any): boolean {
+function getYargsBooleanOrNull(value: any): boolean {
     // Yargs treats a boolean argument as an array of size 2 for null, third is the value of boolean.
-    return mandatory.length > 2 ? mandatory[2] : null;
+    return value && value.length > 2 ? value[2] : null;
 }
 
 function throwForInvalidEmail(email: string): void {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -910,7 +910,7 @@ function patch(command: cli.IPatchCommand): Promise<void> {
         }
     }
 
-    throw new Error("At least one property must be specified.");
+    throw new Error("At least one property must be specified to patch a release.");
 }
 
 export var release = (command: cli.IReleaseCommand): Promise<void> => {

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -277,12 +277,13 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         addCommonConfiguration(yargs);
     })
     .command("patch", "Update the metadata for an existing release", (yargs: yargs.Argv) => {
-        yargs.usage(USAGE_PREFIX + " patch <appName> <deploymentName> [--label <label>] [--description <description>] [--mandatory] [--rollout <rolloutPercentage>]")
+        yargs.usage(USAGE_PREFIX + " patch <appName> <deploymentName> [--label <label>] [--description <description>] [--disabled] [--mandatory] [--rollout <rolloutPercentage>]")
             .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
             .example("patch MyApp Production --des \"Updated description\" -r 50", "Update the description of latest release for \"MyApp\" app's \"Production\" deployment and update rollout value to 50")
             .example("patch MyApp Production -l v3 --des \"Updated description for v3\"", "Update the description of the release with label v3 for \"MyApp\" app's \"Production\" deployment")
             .option("label", { alias: "l", default: null, demand: false, description: "The label of the release to be updated, which defaults to the latest release", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
+            .option("disabled", { alias: "d", default: null, demand: false, description: "Whether to disable this update", type: "boolean" })
             .option("mandatory", { alias: "m", default: null, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" })
             .option("rollout", { alias: "r", default: null, demand: false, description: "The percentage of users this update should be rolled out to. This value can only be increased from the previous value.", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv); });
@@ -595,7 +596,8 @@ function createCommand(): cli.ICommand {
                     patchCommand.appName = arg1;
                     patchCommand.deploymentName = arg2;
                     patchCommand.label = argv["label"];
-                    patchCommand.description = argv["description"] ? backslash(argv["description"]) : "";
+                    patchCommand.description = argv["description"] ? backslash(argv["description"]) : argv["description"];
+                    patchCommand.disabled = argv["disabled"];
                     patchCommand.mandatory = argv["mandatory"];
                     patchCommand.rollout = getRolloutValue(argv["rollout"]);
                 }

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -283,7 +283,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .example("patch MyApp Production -l v3 --des \"Updated description for v3\"", "Update the description of the release with label v3 for \"MyApp\" app's \"Production\" deployment")
             .option("label", { alias: "l", default: null, demand: false, description: "The label of the release to be updated, which defaults to the latest release", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "The description of changes made to the app with this update", type: "string" })
-            .option("disabled", { alias: "d", default: null, demand: false, description: "Whether to disable this update", type: "boolean" })
+            .option("disabled", { alias: "d", default: null, demand: false, description: "Whether to disable this release", type: "boolean" })
             .option("mandatory", { alias: "m", default: null, demand: false, description: "Whether this update should be considered mandatory to the client", type: "boolean" })
             .option("rollout", { alias: "r", default: null, demand: false, description: "The percentage of users this update should be rolled out to. This value can only be increased from the previous value.", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv); });
@@ -596,7 +596,8 @@ function createCommand(): cli.ICommand {
                     patchCommand.appName = arg1;
                     patchCommand.deploymentName = arg2;
                     patchCommand.label = argv["label"];
-                    patchCommand.description = argv["description"] ? backslash(argv["description"]) : argv["description"];
+                    // Description must be set to null to indicate that it is not being patched.
+                    patchCommand.description = argv["description"] ? backslash(argv["description"]) : null;
                     patchCommand.disabled = argv["disabled"];
                     patchCommand.mandatory = argv["mandatory"];
                     patchCommand.rollout = getRolloutValue(argv["rollout"]);

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -747,6 +747,7 @@ describe("CLI", () => {
             appName: "a",
             deploymentName: "Staging",
             label: "v1",
+            disabled: false,
             description: "Patched",
             mandatory: true,
             rollout: 25
@@ -764,13 +765,13 @@ describe("CLI", () => {
             });
     });
 
-
     it("patch command successfully updates latest release", (done: MochaDone): void => {
         var command: cli.IPatchCommand = {
             type: cli.CommandType.patch,
             appName: "a",
             deploymentName: "Staging",
             label: null,
+            disabled: false,
             description: "Patched",
             mandatory: true,
             rollout: 25
@@ -788,6 +789,32 @@ describe("CLI", () => {
             });
     });
 
+    it("patch command fails if no properties were specified for update", (done: MochaDone): void => {
+        var command: cli.IPatchCommand = {
+            type: cli.CommandType.patch,
+            appName: "a",
+            deploymentName: "Staging",
+            label: null,
+            disabled: null,
+            description: null,
+            mandatory: null,
+            rollout: null
+        };
+
+        var patch: Sinon.SinonSpy = sandbox.spy(cmdexec.sdk, "patchRelease");
+
+        cmdexec.execute(command)
+            .then(() => {
+                done(new Error("Did not throw error."));
+            })
+            .catch((err) => {
+                assert.equal(err.message, "At least one property must be specified.");
+                sinon.assert.notCalled(patch);
+                done();
+            })
+            .done();
+    });
+    
     it("promote works successfully", (done: MochaDone): void => {
         var command: cli.IPromoteCommand = {
             type: cli.CommandType.promote,

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -808,7 +808,7 @@ describe("CLI", () => {
                 done(new Error("Did not throw error."));
             })
             .catch((err) => {
-                assert.equal(err.message, "At least one property must be specified.");
+                assert.equal(err.message, "At least one property must be specified to patch a release.");
                 sinon.assert.notCalled(patch);
                 done();
             })

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -38,13 +38,14 @@ declare module "rest-definitions" {
     }
 
     /*inout*/
-    export interface PackageInfo {
+    interface PackageInfo {
         appVersion?: string;
         description?: string;
+        isDisabled?: boolean;
         isMandatory?: boolean;
-        rollout?: number;
         /*generated*/ label?: string;
         /*generated*/ packageHash?: string;
+        rollout?: number;
     }
 
     /*out*/
@@ -52,7 +53,15 @@ declare module "rest-definitions" {
         downloadURL?: string;
         isAvailable: boolean;
         packageSize?: number;
+        shouldRunBinaryVersion?: boolean;
         updateAppVersion?: boolean;
+    }
+
+    /*out*/
+    export interface UpdateCheckCacheResponse {
+        originalPackage: UpdateCheckResponse;
+        rollout?: number;
+        rolloutPackage?: UpdateCheckResponse;
     }
 
     /*in*/
@@ -94,6 +103,11 @@ declare module "rest-definitions" {
     export interface App {
         /*generated*/ collaborators?: CollaboratorMap;
         /*key*/ name: string;
+    }
+
+    /*in*/
+    export interface AppCreationRequest extends App {
+        manuallyProvisionDeployments?: boolean;
     }
 
     /*inout*/

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -38,7 +38,7 @@ declare module "rest-definitions" {
     }
 
     /*inout*/
-    interface PackageInfo {
+    export interface PackageInfo {
         appVersion?: string;
         description?: string;
         isDisabled?: boolean;


### PR DESCRIPTION
This PR allows users to disable (or subsequently re-enable) a particular release using the `code-push patch` command. It also makes the CLI throw an error if no properties are specified for update when using that command.

It also changes the `code-push deployment history` command to indicate whether a particular release is disabled.