### PR TITLE
Forward shouldRunBinaryVersion flag from server

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "1.8.0-beta",
+  "version": "1.9.0-beta",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -118,8 +118,18 @@ export class AcquisitionManager {
             if (!updateInfo) {
                 callback(error, /*remotePackage=*/ null);
                 return;
-            } else if (updateInfo.updateAppVersion) {
-                callback(/*error=*/ null, { updateAppVersion: true, appVersion: updateInfo.appVersion });
+            } else if (updateInfo.updateAppVersion || updateInfo.shouldRunBinaryVersion) {
+                var returnUpdateInfo: any = {};
+                if (updateInfo.shouldRunBinaryVersion) {
+                    returnUpdateInfo.shouldRunBinaryVersion = true;
+                }
+                
+                if (updateInfo.updateAppVersion) {
+                    returnUpdateInfo.updateAppVersion = true;
+                    returnUpdateInfo.appVersion = updateInfo.appVersion;
+                }
+                
+                callback(/*error=*/ null, returnUpdateInfo);
                 return;
             } else if (!updateInfo.isAvailable) {
                 callback(/*error=*/ null, /*remotePackage=*/ null);

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -93,6 +93,30 @@ describe("Acquisition SDK", () => {
         });
     });
 
+    it("SDK forwards shouldRunBinaryVersion notification", (done: MochaDone) => {
+        mockApi.latestPackage.shouldRunBinaryVersion = true;
+        
+        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
+        acquisition.queryUpdateWithCurrentPackage(clone(templateCurrentPackage), (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
+            assert.equal(null, error);
+            assert.deepEqual({ shouldRunBinaryVersion: true }, returnPackage);
+            done();
+        });
+    });
+
+    it("Package with lower native version gives update notification together with shouldRunBinaryVersion notification", (done: MochaDone) => {
+        mockApi.latestPackage.shouldRunBinaryVersion = true;
+        var lowerAppVersionPackage: acquisitionSdk.Package = clone(templateCurrentPackage);
+        lowerAppVersionPackage.appVersion = "0.0.1";
+
+        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
+        acquisition.queryUpdateWithCurrentPackage(lowerAppVersionPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
+            assert.equal(null, error);
+            assert.deepEqual(nativeUpdateResult, returnPackage);
+            done();
+        });
+    });
+
     it("Package with higher native version gives no update", (done: MochaDone) => {
         var higherAppVersionPackage: acquisitionSdk.Package = clone(templateCurrentPackage);
         higherAppVersionPackage.appVersion = "9.9.0";


### PR DESCRIPTION
This change configures the acquisition SDK to forward the `shouldRunBinaryVersion` flag sent by the server to notify client plugins to trigger a rollback to the binary version if needed.