### PR TITLE
Add "disabled" metadata for promote and release + forward shouldRunBinaryVersion flag from server

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -306,7 +306,7 @@ This provides an optional "change log" for the deployment. The value is simply r
 
 #### Disabled parameter
 
-This specifies whether an update should be disabled. A disabled update is one that is not acquirable by clients. If left unspecified, the update will not be disabled, i.e. clients configured to receive updates from the particular deployment will receive the update [if it applies to them](#(#target-binary-version-parameter).
+This specifies whether an update should be disabled. A disabled update is one that is not acquirable by clients. If left unspecified, the update will not be disabled, i.e. clients configured to receive updates from the particular deployment will receive the update [if it applies to them](#target-binary-version-parameter).
 
 *NOTE: This parameter can be set using either "--disabled" or "-x"*
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -239,6 +239,7 @@ Whether you choose to use the platform-specific command that is relevant to your
 code-push release <appName> <updateContents> <targetBinaryVersion>
 [--deploymentName <deploymentName>]
 [--description <description>]
+[--disabled <disabled>]
 [--mandatory]
 [--rollout <rolloutPercentage>]
 ```
@@ -303,6 +304,12 @@ This provides an optional "change log" for the deployment. The value is simply r
 
 *NOTE: This parameter can be set using either "--description" or "-desc"*
 
+#### Disabled parameter
+
+This specifies whether an update should be disabled. A disabled update is one that is not acquirable by clients. If left unspecified, the update will not be disabled, i.e. clients configured to receive updates from the particular deployment will receive the update [if it applies to them](#(#target-binary-version-parameter).
+
+*NOTE: This parameter can be set using either "--disabled" or "-x"*
+
 #### Mandatory parameter
 
 This specifies whether the update should be considered mandatory or not (e.g. it includes a critical security fix). This attribute is simply round tripped to the client, who can then decide if and how they would like to enforce it.
@@ -349,6 +356,7 @@ code-push release-react <appName> <platform>
 [--deploymentName <deploymentName>]
 [--description <description>]
 [--development <development>]
+[--disabled <disabled>]
 [--entryFile <entryFile>]
 [--mandatory]
 [--sourcemapOutput <sourcemapOutput>]
@@ -359,7 +367,7 @@ code-push release-react <appName> <platform>
 The `release-react` command does two things in addition to running the vanilla `release` command described in the [previous section](#releasing-app-updates):
 
 1. It runs the [`react-native bundle` command](#update-contents-parameter) to generate the update contents in a temporary folder
-2. It infers the [`targetBinaryVersion` of this release](#target-binary-range-parameter) by reading the contents of the project's metadata (`Info.plist` if this update is for iOS clients, and `build.gradle` for Android clients), and defaults to target only the specified version in the metadata.
+2. It infers the [`targetBinaryVersion` of this release](#target-binary-version-parameter) by reading the contents of the project's metadata (`Info.plist` if this update is for iOS clients, and `build.gradle` for Android clients), and defaults to target only the specified version in the metadata.
 
 It then calls the vanilla `release` command by supplying the values for the required parameters using the above information. Doing this helps you avoid the manual step of generating the update contents yourself using the `react-native bundle` command and also avoid common pitfalls such as supplying an invalid `targetBinaryVersion` parameter.
 
@@ -382,6 +390,10 @@ This is the same parameter as the one described in the [above section](#descript
 #### Development parameter
 
 This specifies whether to generate a unminified, development JS bundle. If left unspecified, this defaults to `false` where warnings are disabled and the bundle is minified.
+
+#### Disabled parameter
+
+This is the same parameter as the one described in the [above section](#disabled-parameter).
 
 #### Entry file parameter
 
@@ -417,7 +429,7 @@ code-push release-cordova <appName> <platform>
 The `release-cordova` command does two things in addition to running the vanilla `release` command described in the [Releasing App Updates](#releasing-app-updates) section:
 
 1. It [updates the contents](#update-contents-parameter) of the package by calling `cordova prepare` for the specified platform
-2. It infers the [`targetBinaryVersion` of this release](#target-binary-range-parameter) by reading the version in the `<widget version>` in config.xml, and defaults to target only the specified version.
+2. It infers the [`targetBinaryVersion` of this release](#target-binary-version-parameter) by reading the version in the `<widget version>` in config.xml, and defaults to target only the specified version.
 
 It then calls the vanilla `release` command by supplying the values for the required parameters using the above information. Doing this helps you avoid the manual step of generating the update contents yourself using the `cordova prepare` command and also avoid common pitfalls such as supplying an invalid `targetBinaryVersion` parameter.
 
@@ -432,6 +444,10 @@ This is the same parameter as the one described in the [above section](#deployme
 #### Description parameter
 
 This is the same parameter as the one described in the [above section](#description-parameter).
+
+#### Disabled parameter
+
+This is the same parameter as the one described in the [above section](#disabled-parameter).
 
 #### Mandatory parameter
 
@@ -473,6 +489,10 @@ This is the same parameter as the one described in the [above section](#mandator
 
 This is the same parameter as the one described in the [above section](#description-parameter), and simply allows you to update the description associated with the release (e.g. you made a typo when releasing, or you forgot to add a description at all). If this parameter is ommitted, no change will be made to the value of the target release's description property. 
 
+#### Disabled parameter
+
+This is the same parameter as the one described in the [above section](#disabled-parameter), and simply allows you to update whether the release should be disabled or not. Note that `--disabled` and `--disabled true` are equivalent, but the absence of this flag is not equivalent to `--disabled false`. Therefore, if the paremeter is ommitted, no change will be made to the value of the target release's disabled property. You need to set this to `--disabled false` to explicity make a release acquirable if it was previously disabled.
+
 #### Rollout Parameter
 
 This is the same parameter as the one described in the [above section](#rollout-parameter), and simply allows you to increase the rollout percentage of the target release. This parameter can only be set to an integer whose value is greater than the current rollout value. Additionally, if you want to "complete" the rollout, and therefore, make the release available to everyone, you can simply set this parameter to `--rollout 100`. If this parameter is ommitted, no change will be made to the value of the target release's rollout parameter.
@@ -486,6 +506,7 @@ Once you've tested an update against a specific deployment (e.g. `Staging`), and
 ```
 code-push promote <appName> <sourceDeploymentName> <destDeploymentName>
 [--description <description>]
+[--disabled <disabled>]
 [--mandatory]
 [--rollout <rolloutPercentage>]
 ```
@@ -501,6 +522,10 @@ We recommend that all users take advantage of the automatically created `Staging
 ### Description parameter
 
 This is the same parameter as the one described in the [above section](#description-parameter), and simply allows you to override the description that will be used for the promoted release. If unspecified, the new release will inherit the description from the release being promoted.
+
+#### Disabled parameter
+
+This is the same parameter as the one described in the [above section](#disabled-parameter), and simply allows you to override the value of the disabled flag that will be used for the promoted release. If unspecified, the new release will inherit the disabled property from the release being promoted.
 
 ### Mandatory parameter
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -122,6 +122,7 @@ export interface ILoginCommand extends ICommand {
 
 export interface IPackageInfo {
     description?: string;
+    disabled?: boolean;
     mandatory?: boolean;
     rollout?: number;
 }
@@ -129,7 +130,6 @@ export interface IPackageInfo {
 export interface IPatchCommand extends ICommand, IPackageInfo {
     appName: string;
     deploymentName: string;
-    disabled: boolean;
     label: string;
 }
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push-cli",
-  "version": "1.8.0-beta",
+  "version": "1.8.1-beta",
   "description": "Management CLI for the CodePush service",
   "main": "script/cli.js",
   "scripts": {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -741,12 +741,18 @@ function getPackageString(packageObject: Package): string {
         return chalk.magenta("No updates released").toString();
     }
 
-    return chalk.green("Label: ") + packageObject.label + "\n" +
+    var packageString: string = chalk.green("Label: ") + packageObject.label + "\n" +
         chalk.green("App Version: ") + packageObject.appVersion + "\n" +
         chalk.green("Mandatory: ") + (packageObject.isMandatory ? "Yes" : "No") + "\n" +
         chalk.green("Release Time: ") + formatDate(packageObject.uploadTime) + "\n" +
         chalk.green("Released By: ") + (packageObject.releasedBy ? packageObject.releasedBy : "") +
         (packageObject.description ? wordwrap(70)("\n" + chalk.green("Description: ") + packageObject.description) : "");
+        
+    if (packageObject.isDisabled) {
+        packageString += `\n${chalk.green("Disabled:")} Yes`;
+    }
+    
+    return packageString;
 }
 
 function getPackageMetricsString(obj: Package): string {
@@ -880,10 +886,10 @@ function register(command: cli.IRegisterCommand): Promise<void> {
 }
 
 function promote(command: cli.IPromoteCommand): Promise<void> {
-    var isMandatory: boolean = getYargsBooleanOrNull(command.mandatory);
     var packageInfo: PackageInfo = {
         description: command.description,
-        isMandatory: isMandatory,
+        isDisabled: getYargsBooleanOrNull(command.disabled),
+        isMandatory: getYargsBooleanOrNull(command.mandatory),
         rollout: command.rollout
     };
 
@@ -981,6 +987,7 @@ export var release = (command: cli.IReleaseCommand): Promise<void> => {
 
     var updateMetadata: PackageInfo = {
         description: command.description,
+        isDisabled: command.disabled,
         isMandatory: command.mandatory,
         rollout: command.rollout
     };

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "1.9.0-beta",
+  "version": "1.8.1-beta",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "1.8.0-beta",
+  "version": "1.9.0-beta",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -118,8 +118,18 @@ export class AcquisitionManager {
             if (!updateInfo) {
                 callback(error, /*remotePackage=*/ null);
                 return;
-            } else if (updateInfo.updateAppVersion) {
-                callback(/*error=*/ null, { updateAppVersion: true, appVersion: updateInfo.appVersion });
+            } else if (updateInfo.updateAppVersion || updateInfo.shouldRunBinaryVersion) {
+                var returnUpdateInfo: any = {};
+                if (updateInfo.shouldRunBinaryVersion) {
+                    returnUpdateInfo.shouldRunBinaryVersion = true;
+                }
+                
+                if (updateInfo.updateAppVersion) {
+                    returnUpdateInfo.updateAppVersion = true;
+                    returnUpdateInfo.appVersion = updateInfo.appVersion;
+                }
+                
+                callback(/*error=*/ null, returnUpdateInfo);
                 return;
             } else if (!updateInfo.isAvailable) {
                 callback(/*error=*/ null, /*remotePackage=*/ null);

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -93,6 +93,30 @@ describe("Acquisition SDK", () => {
         });
     });
 
+    it("SDK forwards shouldRunBinaryVersion notification", (done: MochaDone) => {
+        mockApi.latestPackage.shouldRunBinaryVersion = true;
+        
+        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
+        acquisition.queryUpdateWithCurrentPackage(clone(templateCurrentPackage), (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
+            assert.equal(null, error);
+            assert.deepEqual({ shouldRunBinaryVersion: true }, returnPackage);
+            done();
+        });
+    });
+
+    it("Package with lower native version gives update notification together with shouldRunBinaryVersion notification", (done: MochaDone) => {
+        mockApi.latestPackage.shouldRunBinaryVersion = true;
+        var lowerAppVersionPackage: acquisitionSdk.Package = clone(templateCurrentPackage);
+        lowerAppVersionPackage.appVersion = "0.0.1";
+
+        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
+        acquisition.queryUpdateWithCurrentPackage(lowerAppVersionPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
+            assert.equal(null, error);
+            assert.deepEqual(nativeUpdateResult, returnPackage);
+            done();
+        });
+    });
+
     it("Package with higher native version gives no update", (done: MochaDone) => {
         var higherAppVersionPackage: acquisitionSdk.Package = clone(templateCurrentPackage);
         higherAppVersionPackage.appVersion = "9.9.0";


### PR DESCRIPTION
This change allows users to specify the "disabled" metadata when releasing or promoting an update.

Also combined this PR with https://github.com/Microsoft/code-push/pull/174, which configures the acquisition SDK to forward the `shouldRunBinaryVersion` flag sent by the server to notify client plugins to trigger a rollback to the binary version if needed.