### PR TITLE
Compensate for git bash on Windows when parsing custom server urls

### DIFF
--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -729,7 +729,7 @@ function getServerUrl(url: string): string {
         url = url.substring(0, url.length - 1);
     }
 
-    url = url.replace(/^(https?):\\/, "$1://");     // Replace 'http:\' with 'http://' for Windows Git Bash
+    url = url.replace(/^(https?):\\/, "$1://");     // Replace 'http(s):\' with 'http(s)://' for Windows Git Bash
 
     return url;
 }

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -378,7 +378,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
     .check((argv: any, aliases: { [aliases: string]: string }): any => isValidCommandCategory)  // Report unrecognized, non-hyphenated command category.
     .fail((msg: string) => showHelp(/*showRootDescription*/ true))  // Suppress the default error message.
     .argv;
-    
+
 function createCommand(): cli.ICommand {
     var cmd: cli.ICommand;
 
@@ -649,7 +649,7 @@ function createCommand(): cli.ICommand {
                     releaseCommand.rollout = getRolloutValue(argv["rollout"]);
                 }
                 break;
-                
+
             case "release-cordova":
                 if (arg1 && arg2) {
                     cmd = { type: cli.CommandType.releaseCordova };
@@ -728,6 +728,8 @@ function getServerUrl(url: string): string {
     if (url[url.length - 1] === "/") {
         url = url.substring(0, url.length - 1);
     }
+
+    url = url.replace(/^(https?):\\/, "$1://");     // Replace 'http:\' with 'http://' for Windows Git Bash
 
     return url;
 }


### PR DESCRIPTION
This is a quick tweak purely for the sake of internal testing, as custom server URL's are not needed by end users.

A major annoyance for the longest time when using Git Bash on Windows is that, due to path translation, a URL like `http://localhost:3000` passed on the command-line ends up as `http:\localhost:3000` by the time it ends up in our CLI. This just compensates for that by translating it back.