### PR TITLE
Version bump

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push-cli",
-  "version": "1.8.1-beta",
+  "version": "1.8.2-beta",
   "description": "Management CLI for the CodePush service",
   "main": "script/cli.js",
   "scripts": {


### PR DESCRIPTION
Simply bumping the version to be able to ship the `release-cordova` bug on Windows to NPM.