### PR TITLE
Adding whoami command

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -56,13 +56,19 @@ Note that in order to do this, the email address used on the provider must match
 
 ## Authentication
 
-Every command within the CodePush CLI requires authentication, and therefore, before you can begin managing your account, you need to login using the GitHub or Microsoft account you used when registering. You can do this by running the following command:
+Most commands within the CodePush CLI require authentication, and therefore, before you can begin managing your account, you need to login using the GitHub or Microsoft account you used when registering. You can do this by running the following command:
 
 ```
 code-push login
 ```
 
 This will launch a browser, asking you to authenticate with either your GitHub or Microsoft account. This will generate an access key that you need to copy/paste into the CLI (it will prompt you for it). You are now successfully authenticated and can safely close your browser window.
+
+If at anytime you want to determine if you're already logged in, and if so, with which account, you can run the following command to display the e-mail address associated with your current authentication session:
+
+```shell
+code-push whoami
+```
 
 When you login from the CLI, your access key is persisted to disk for the duration of your session so that you don't have to login every time you attempt to access your account. In order to end your session and delete this access key, simply run the following command:
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -26,7 +26,8 @@
     release,
     releaseCordova,
     releaseReact,
-    rollback
+    rollback,
+    whoami
 }
 
 export interface ICommand {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1285,7 +1285,7 @@ function throwForInvalidOutputFormat(format: string): void {
 
 function whoami(command: cli.ICommand): Promise<void> {
     return sdk.getAccountInfo()
-            .then((account): void => {
-                log(account.email);
-            });
+        .then((account): void => {
+            log(account.email);
+        });
 }

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -502,6 +502,9 @@ export function execute(command: cli.ICommand): Promise<void> {
                 case cli.CommandType.rollback:
                     return rollback(<cli.IRollbackCommand>command);
 
+                case cli.CommandType.whoami:
+                    return whoami(command);
+                    
                 default:
                     // We should never see this message as invalid commands should be caught by the argument parser.
                     throw new Error("Invalid command:  " + JSON.stringify(command));
@@ -1278,4 +1281,11 @@ function throwForInvalidOutputFormat(format: string): void {
         default:
             throw new Error("Invalid format:  " + format + ".");
     }
+}
+
+function whoami(command: cli.ICommand): Promise<void> {
+    return sdk.getAccountInfo()
+            .then((account): void => {
+                log(account.email);
+            });
 }

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -381,6 +381,14 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
 
         addCommonConfiguration(yargs);
     })
+    .command("whoami", "Displays the e-mail address you are currently logged in with", (yargs: yargs.Argv) => {
+        isValidCommandCategory = true;
+        isValidCommand = true;
+        yargs.usage(USAGE_PREFIX + " whoami")
+            .demand(/*count*/ 1, /*max*/ 1)  // Require exactly one non-option argument.
+            .example("whoami", "Displays the e-mail address you are currently logged in with");
+        addCommonConfiguration(yargs);
+    })
     .alias("v", "version")
     .version(packageJson.version)
     .wrap(/*columnLimit*/ null)
@@ -714,6 +722,10 @@ function createCommand(): cli.ICommand {
                     rollbackCommand.deploymentName = arg2;
                     rollbackCommand.targetRelease = argv["targetRelease"];
                 }
+                break;
+                
+            case "whoami":
+                cmd = { type: cli.CommandType.whoami };
                 break;
         }
 


### PR DESCRIPTION
This PR introduces a new `code-push whoami` command which allows users to determine if they are already logged in, and if so, with which e-mail address. This command mirrors the equivalent in the NPM CLI.

<img width="829" alt="screen shot 2016-03-25 at 1 51 27 pm" src="https://cloud.githubusercontent.com/assets/116461/14053749/c39164ae-f290-11e5-9dd7-5005fd14bf96.png">
