### PR TITLE
Adding linked providers to whoami

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -64,7 +64,7 @@ code-push login
 
 This will launch a browser, asking you to authenticate with either your GitHub or Microsoft account. This will generate an access key that you need to copy/paste into the CLI (it will prompt you for it). You are now successfully authenticated and can safely close your browser window.
 
-If at anytime you want to determine if you're already logged in, and if so, with which account, you can run the following command to display the e-mail address associated with your current authentication session, and which identity providers your account is linked to (e.g. GitHub):
+If at anytime you want to determine if you're already logged in, you can run the following command to display the e-mail address associated with your current authentication session, and which identity providers your account is linked to (e.g. GitHub):
 
 ```shell
 code-push whoami

--- a/cli/README.md
+++ b/cli/README.md
@@ -64,7 +64,7 @@ code-push login
 
 This will launch a browser, asking you to authenticate with either your GitHub or Microsoft account. This will generate an access key that you need to copy/paste into the CLI (it will prompt you for it). You are now successfully authenticated and can safely close your browser window.
 
-If at anytime you want to determine if you're already logged in, and if so, with which account, you can run the following command to display the e-mail address associated with your current authentication session:
+If at anytime you want to determine if you're already logged in, and if so, with which account, you can run the following command to display the e-mail address associated with your current authentication session, and which identity providers your account is linked to (e.g. GitHub):
 
 ```shell
 code-push whoami

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1286,6 +1286,6 @@ function throwForInvalidOutputFormat(format: string): void {
 function whoami(command: cli.ICommand): Promise<void> {
     return sdk.getAccountInfo()
         .then((account): void => {
-            log(account.email);
+            log(`${account.email} (${account.linkedProviders.join(", ")})`);
         });
 }

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -86,6 +86,7 @@ declare module "rest-definitions" {
     export interface Account {
         /*key*/ email: string;
         name: string;
+        linkedProviders: string[];
     }
 
     /*out*/


### PR DESCRIPTION
This PR enhanced the `whoami` command by also displaying the list of identity providers that your account is linked with. 