### PR TITLE
Update rest definitions for improving diffs

### DIFF
--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -118,12 +118,21 @@ declare module "rest-definitions" {
         /*generated*/ package?: Package
     }
 
+    /*out*/
+    export interface BlobInfo {
+        size: number;
+        url: string;
+    }
+
+    /*out*/
+    export interface PackageHashToBlobInfoMap {
+        [packageHash: string]: BlobInfo;
+    }
+
     /*inout*/
     export interface Package extends PackageInfo {
         /*generated*/ blobUrl: string;
-        /*generated*/ diffAgainstPackageHash?: string;
-        /*generated*/ diffBlobUrl?: string;
-        /*generated*/ diffSize?: number;
+        /*generated*/ diffPackageMap?: PackageHashToBlobInfoMap;
         /*generated*/ originalLabel?: string;       // Set on "Promote" and "Rollback"
         /*generated*/ originalDeployment?: string;  // Set on "Promote"
         /*generated*/ releasedBy?: string;          // Set by commitPackage

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "1.8.1-beta",
+  "version": "1.9.0-beta",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/plugin.xml
+++ b/sdk/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="code-push" version="1.8.0-beta">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="code-push" version="1.9.0-beta">
 	<name>CodePushAcquisition</name>
 	<description>CodePush Acquisition Plugin for Apache Cordova</description>
 	<license>MIT</license>


### PR DESCRIPTION
Updating the SDK version to reflect change of object structure for package.

Although none of the clients use this change, keeping the definitions in sync with the server change.