### PR TITLE
Bumping version

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push-cli",
-  "version": "1.9.1-beta",
+  "version": "1.10.0-beta",
   "description": "Management CLI for the CodePush service",
   "main": "script/cli.js",
   "scripts": {


### PR DESCRIPTION
Bumping the minor version to release the new Windows support in the `release-react` command and the new `--build` flag for `release-cordova`.