### PR TITLE
Bump gradle-to-js to version 0.1.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,7 @@
     "cli-table": "^0.3.1",
     "code-push": "1.8.0-beta",
     "email-validator": "^1.0.3",
-    "gradle-to-js": "geof90/gradle-to-js",
+    "gradle-to-js": "0.1.0",
     "moment": "^2.10.6",
     "opener": "^1.4.1",
     "plist": "1.2.0",


### PR DESCRIPTION
Hello world!

@geof90 has kindly contributed his improvement into the main repo, and I thought that I'd let you know that the changes are now available in version `0.1.0`. You can merge this PR if you feel like jumping on the NPM registry track again, or just close if you don't.  :-)

Have a great weekend!