### PR TITLE
Adding PhoneGap support to release-cordova

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -42,6 +42,7 @@
     "semver": "4.3.6",
     "slash": "1.0.0",
     "update-notifier": "^0.5.0",
+    "which": "^1.2.7",
     "wordwrap": "1.0.0",
     "xml2js": "^0.4.16",
     "yargs": "^3.15.0",


### PR DESCRIPTION
This PR fixes #219 by simply checking for the presence of both the `cordova` and `phonegap` CLIs in order to prepare/build the project. Note that we don't need to worry about supporting `ionic`, since it uses `cordova` under the covers, and therefore, a machine with `ionic` installed, but not `cordova`, wouldn't actually work. Only `cordova` and `phonegap` are "standalone" tools.