### PR TITLE
Lowercasing "ios" directory in release-react

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -823,14 +823,14 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string):
     var missingPatchVersionRegex: RegExp = /^\d+\.\d+$/;
     if (platform === "ios") {
         try {
-            var infoPlistContainingFolder: string = path.join("iOS", projectName);
+            var infoPlistContainingFolder: string = path.join("ios", projectName);
             var infoPlistContents: string = fs.readFileSync(path.join(infoPlistContainingFolder, "Info.plist")).toString();
         } catch (err) {
             try {
-                infoPlistContainingFolder = "iOS";
+                infoPlistContainingFolder = "ios";
                 infoPlistContents = fs.readFileSync(path.join(infoPlistContainingFolder, "Info.plist")).toString();
             } catch (err) {
-                throw new Error(`Unable to find or read "Info.plist" in the "iOS/${projectName}" or "iOS" folders.`);
+                throw new Error(`Unable to find or read "Info.plist" in the "ios/${projectName}" or "ios" folders.`);
             }
         }
 


### PR DESCRIPTION
This PR fixes [react-native-code-push#329](https://github.com/Microsoft/react-native-code-push/issues/329) by simply lowercasing the "ios" directory we use when trying to auto-detect the app's binary version. The React Native templates have always generated a lowercased "ios" directory, and therefore, we should have already been using this. On Windows and most OS X machines, it wouldn't matter either way, but as noted by the bug, on Linux machines, case  matters, and therefore, this PR enables us to work across all platforms by default. 

If someone were to change the "ios" directory to be named "iOS" or "IoS" (or whatever), and run `release-react` on a machine with a case-sensitive file-system (e.g. Linux), this PR wouldn't address that scenario. However, I don't believe this is a common scenario at all, so I decided not to worry about it prematurely.