### PR TITLE
Add yargs check for missing deployment name.

### DIFF
--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -342,7 +342,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("disabled", { alias: "x", default: false, demand: false, description: "Specifies whether this release should be immediately downloadable", type: "boolean" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Specifies whether this release should be considered mandatory", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be available to", type: "string" })
-            .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv) && isValidDeploymentName(argv); });
+            .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
         addCommonConfiguration(yargs);
     })
@@ -358,7 +358,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Specifies whether this release should be considered mandatory", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the config.xml file.", type: "string" })
-            .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv) && isValidDeploymentName(argv); });
+            .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
         addCommonConfiguration(yargs);
     })
@@ -378,7 +378,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("sourcemapOutput", { alias: "s", default: null, demand: false, description: "Path to where the sourcemap for the resulting bundle should be written. If omitted, a sourcemap will not be generated.", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the \"Info.plist\" (iOS), \"build.gradle\" (Android) or \"Package.appxmanifest\" (Windows) files.", type: "string" })
-            .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv) && isValidDeploymentName(argv); });
+            .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
         addCommonConfiguration(yargs);
     })
@@ -760,8 +760,8 @@ function isValidRollout(args: any): boolean {
     return true;
 }
 
-function isValidDeploymentName(args: any): boolean {
-    return !!args["deploymentName"];    
+function checkValidReleaseOptions(args: any): boolean {
+    return isValidRollout(args) && !!args["deploymentName"];    
 }
 
 function getRolloutValue(input: string): number {

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -751,7 +751,6 @@ function createCommand(): cli.ICommand {
 }
 
 function isValidRollout(args: any): boolean {
-    var deploymentName: string = args["deploymentName"];
     var rollout: string = args["rollout"];
     if (rollout && !ROLLOUT_PERCENTAGE_REGEX.test(rollout)) {
         return false;

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -342,7 +342,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("disabled", { alias: "x", default: false, demand: false, description: "Specifies whether this release should be immediately downloadable", type: "boolean" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Specifies whether this release should be considered mandatory", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be available to", type: "string" })
-            .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv); });
+            .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv) && isValidDeploymentName(argv); });
 
         addCommonConfiguration(yargs);
     })
@@ -358,7 +358,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Specifies whether this release should be considered mandatory", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the config.xml file.", type: "string" })
-            .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv); });
+            .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv) && isValidDeploymentName(argv); });
 
         addCommonConfiguration(yargs);
     })
@@ -378,7 +378,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("sourcemapOutput", { alias: "s", default: null, demand: false, description: "Path to where the sourcemap for the resulting bundle should be written. If omitted, a sourcemap will not be generated.", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the \"Info.plist\" (iOS), \"build.gradle\" (Android) or \"Package.appxmanifest\" (Windows) files.", type: "string" })
-            .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv); });
+            .check((argv: any, aliases: { [aliases: string]: string }): any => { return isValidRollout(argv) && isValidDeploymentName(argv); });
 
         addCommonConfiguration(yargs);
     })
@@ -751,12 +751,17 @@ function createCommand(): cli.ICommand {
 }
 
 function isValidRollout(args: any): boolean {
+    var deploymentName: string = args["deploymentName"];
     var rollout: string = args["rollout"];
     if (rollout && !ROLLOUT_PERCENTAGE_REGEX.test(rollout)) {
         return false;
     }
 
     return true;
+}
+
+function isValidDeploymentName(args: any): boolean {
+    return !!args["deploymentName"];    
 }
 
 function getRolloutValue(input: string): number {


### PR DESCRIPTION
Fixes #220 - empty option for deploymentName yargs parameter calls into the wrong route.