### PR TITLE
Revert 8122188

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -28,7 +28,7 @@
     "base-64": "^0.1.0",
     "chalk": "^1.1.0",
     "cli-table": "^0.3.1",
-    "code-push": "1.9.0-beta",
+    "code-push": "1.9.1-beta",
     "email-validator": "^1.0.3",
     "gradle-to-js": "0.1.0",
     "moment": "^2.10.6",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "1.9.0-beta",
+  "version": "1.9.1-beta",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -118,18 +118,8 @@ export class AcquisitionManager {
             if (!updateInfo) {
                 callback(error, /*remotePackage=*/ null);
                 return;
-            } else if (updateInfo.updateAppVersion || updateInfo.shouldRunBinaryVersion) {
-                var returnUpdateInfo: any = {};
-                if (updateInfo.shouldRunBinaryVersion) {
-                    returnUpdateInfo.shouldRunBinaryVersion = true;
-                }
-                
-                if (updateInfo.updateAppVersion) {
-                    returnUpdateInfo.updateAppVersion = true;
-                    returnUpdateInfo.appVersion = updateInfo.appVersion;
-                }
-                
-                callback(/*error=*/ null, returnUpdateInfo);
+            } else if (updateInfo.updateAppVersion) {
+                callback(/*error=*/ null, { updateAppVersion: true, appVersion: updateInfo.appVersion });
                 return;
             } else if (!updateInfo.isAvailable) {
                 callback(/*error=*/ null, /*remotePackage=*/ null);
@@ -150,22 +140,22 @@ export class AcquisitionManager {
             callback(/*error=*/ null, remotePackage);
         });
     }
-    
+
     public reportStatusDeploy(deployedPackage?: Package, status?: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string, callback?: Callback<void>): void {
         var url: string = this._serverUrl + "reportStatus/deploy";
         var body: DeploymentStatusReport = {
             appVersion: this._appVersion,
             deploymentKey: this._deploymentKey
         };
-        
+
         if (this._clientUniqueId) {
             body.clientUniqueId = this._clientUniqueId;
         }
-        
+
         if (deployedPackage) {
             body.label = deployedPackage.label;
             body.appVersion = deployedPackage.appVersion;
-            
+
             switch (status) {
                 case AcquisitionStatus.DeploymentSucceeded:
                 case AcquisitionStatus.DeploymentFailed:
@@ -183,17 +173,17 @@ export class AcquisitionManager {
                     return;
             }
         }
-        
+
         if (previousLabelOrAppVersion) {
             body.previousLabelOrAppVersion = previousLabelOrAppVersion;
         }
-        
+
         if (previousDeploymentKey) {
             body.previousDeploymentKey = previousDeploymentKey;
         }
-        
+
         callback = typeof arguments[arguments.length - 1] === "function" && arguments[arguments.length - 1];
-        
+
         this._httpRequester.request(Http.Verb.POST, url, JSON.stringify(body), (error: Error, response: Http.Response): void => {
             if (callback) {
                 if (error) {
@@ -210,7 +200,7 @@ export class AcquisitionManager {
             }
         });
     }
-    
+
     public reportStatusDownload(downloadedPackage: Package, callback?: Callback<void>): void {
         var url: string = this._serverUrl + "reportStatus/download";
         var body: DownloadReport = {
@@ -218,7 +208,7 @@ export class AcquisitionManager {
             deploymentKey: this._deploymentKey,
             label: downloadedPackage.label
         };
-        
+
         this._httpRequester.request(Http.Verb.POST, url, JSON.stringify(body), (error: Error, response: Http.Response): void => {
             if (callback) {
                 if (error) {

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -93,19 +93,6 @@ describe("Acquisition SDK", () => {
         });
     });
 
-    it("Package with lower native version gives update notification together with shouldRunBinaryVersion notification", (done: MochaDone) => {
-        mockApi.latestPackage.shouldRunBinaryVersion = true;
-        var lowerAppVersionPackage: acquisitionSdk.Package = clone(templateCurrentPackage);
-        lowerAppVersionPackage.appVersion = "0.0.1";
-
-        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
-        acquisition.queryUpdateWithCurrentPackage(lowerAppVersionPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
-            assert.equal(null, error);
-            assert.deepEqual(nativeUpdateResult, returnPackage);
-            done();
-        });
-    });
-
     it("Package with higher native version gives no update", (done: MochaDone) => {
         var higherAppVersionPackage: acquisitionSdk.Package = clone(templateCurrentPackage);
         higherAppVersionPackage.appVersion = "9.9.0";

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -93,17 +93,6 @@ describe("Acquisition SDK", () => {
         });
     });
 
-    it("SDK forwards shouldRunBinaryVersion notification", (done: MochaDone) => {
-        mockApi.latestPackage.shouldRunBinaryVersion = true;
-        
-        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
-        acquisition.queryUpdateWithCurrentPackage(clone(templateCurrentPackage), (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
-            assert.equal(null, error);
-            assert.deepEqual({ shouldRunBinaryVersion: true }, returnPackage);
-            done();
-        });
-    });
-
     it("Package with lower native version gives update notification together with shouldRunBinaryVersion notification", (done: MochaDone) => {
         mockApi.latestPackage.shouldRunBinaryVersion = true;
         var lowerAppVersionPackage: acquisitionSdk.Package = clone(templateCurrentPackage);
@@ -236,7 +225,7 @@ describe("Acquisition SDK", () => {
             done();
         }));
     });
-    
+
     it("reportStatusDownload(...) signals completion", (done: MochaDone): void => {
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
 


### PR DESCRIPTION
This PR reverts https://github.com/Microsoft/code-push/commit/812218858b1afc170d1addc2c625ede267d53e75 because it breaks the Cordova plugin which blindly assumes that a returned object is an update.