### PR TITLE
Access key changes

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -120,7 +120,7 @@ When logging in via this method, the access key will not be automatically invali
 Finally, if you need to change a key's name or expiry date, you can use the following command:
 
 ```
-code-push access-key edit <accessKeyName> --name "new name" --ttl 10d
+code-push access-key patch <accessKeyName> --name "new name" --ttl 10d
 ```
 
 ## App Management

--- a/cli/README.md
+++ b/cli/README.md
@@ -21,7 +21,7 @@ CodePush is a cloud service that enables Cordova and React Native developers to 
 * [Viewing Release History](#viewing-release-history)
 * [Clearing Release History](#clearing-release-history)
 
-[[中文版]](./README-cn.md)
+[[Chinese version 中文版]](./README-cn.md)
 
 ## Installation
 
@@ -94,18 +94,20 @@ code-push logout
 ```
 
 If you forget to logout from a machine you'd prefer not to leave a running session on (e.g. your friend's laptop), you can use the following commands to list and remove any "live" access keys.
-The list of access keys will display the name of the machine the key was created on, as well as the time the login occurred. This should make it easy to spot keys you don't want to keep around.
+The list of access keys will display the name of the machine the key was created on, the time the login occurred, and the time it expires. This should make it easy to spot keys you don't want to keep around.
 
 ```
 code-push access-key ls
-code-push access-key rm <accessKey>
+code-push access-key rm <accessKeyName>
 ```
 
-If you need additional keys that can be used to authenticate against the CodePush service without needing to give access to your GitHub and/or Microsoft credentials, you can run the following command to create a persistent one (along with a description of what it is for):
+If you need additional keys that can be used to authenticate against the CodePush service without needing to give access to your GitHub and/or Microsoft credentials, you can run the following command to create a persistent one (along with a name describing what it is for):
 
 ```
 code-push access-key add "VSTS Integration"
 ```
+
+By default, access keys expire in 60 days. You can specify a different expiry duration by using the `--maxAge` option and passing in a [human readable duration string](https://github.com/jkroso/parse-duration#parsestr) (e.g. "2d" => 2 days, "1h 15 min" => 1 hour and 15 minutes). For security, the key will only be shown once on creation, so remember to save it somewhere if needed!
 
 After creating the new key, you can specify its value using the `--accessKey` flag of the `login` command, which allows you to perform "headless" authentication, as opposed to launching a browser.
 
@@ -114,6 +116,12 @@ code-push login --accessKey <accessKey>
 ```
 
 When logging in via this method, the access key will not be automatically invalidated on logout, and can be used in future sessions until it is explicitly removed from the CodePush server. However, it is still recommended to log out once your session is complete, in order to remove your credentials from disk.
+
+Finally, if you need to change a key's name or expiry date, you can use the following command:
+
+```
+code-push access-key edit <accessKeyName> --name "new name" --maxAge 10d
+```
 
 ## App Management
 
@@ -248,7 +256,7 @@ The install metrics have the following meaning:
 
 * **Rollbacks** - The number of times that this release has been automatically rolled back on the client. Ideally this number should be zero, and in that case, this metric isn't even shown. However, if you released an update that includes a crash as part of the installation process, the CodePush plugin will roll the end-user back to the previous release, and report that issue back to the server. This allows your end-users to remain unblocked in the event of broken releases, and by being able to see this telemetry in the CLI, you can identify erroneous releases and respond to them by [rolling it back](#rolling-back-undesired-updates) on the server.
 
-* **Rollout** - Indicates the percentage of users that are elligble to receive this update. This property will only be displayed for releases that represent an "active" rollout, and therefore, have a rollout percentage that is less than 100%. Additionally, since a deployment can only have one active rollout at any given time, this label would only be present on the latest release within a deployment. 
+* **Rollout** - Indicates the percentage of users that are elligble to receive this update. This property will only be displayed for releases that represent an "active" rollout, and therefore, have a rollout percentage that is less than 100%. Additionally, since a deployment can only have one active rollout at any given time, this label would only be present on the latest release within a deployment.
 
 * **Disabled** - Indicates whether the release has been marked as disabled or not, and therefore, is downloadable by end users. This property will only be displayed for releases that are actually disabled.
 
@@ -657,7 +665,7 @@ This is the same parameter as the one described in the [above section](#rollout-
 This is the same parameter as the one described in the [above section](#target-binary-version-parameter), and simply allows you to override the target binary version that will be used for the promoted release. If unspecified, the new release will inherit the target binary version property from the release being promoted.
 
 ```shell
-# Promote the release to production and make it 
+# Promote the release to production and make it
 # available to all versions using that deployment
 code-push promote MyApp Staging Production -t "*"
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -256,7 +256,7 @@ The install metrics have the following meaning:
 
 * **Rollbacks** - The number of times that this release has been automatically rolled back on the client. Ideally this number should be zero, and in that case, this metric isn't even shown. However, if you released an update that includes a crash as part of the installation process, the CodePush plugin will roll the end-user back to the previous release, and report that issue back to the server. This allows your end-users to remain unblocked in the event of broken releases, and by being able to see this telemetry in the CLI, you can identify erroneous releases and respond to them by [rolling it back](#rolling-back-undesired-updates) on the server.
 
-* **Rollout** - Indicates the percentage of users that are elligble to receive this update. This property will only be displayed for releases that represent an "active" rollout, and therefore, have a rollout percentage that is less than 100%. Additionally, since a deployment can only have one active rollout at any given time, this label would only be present on the latest release within a deployment.
+* **Rollout** - Indicates the percentage of users that are eligible to receive this update. This property will only be displayed for releases that represent an "active" rollout, and therefore, have a rollout percentage that is less than 100%. Additionally, since a deployment can only have one active rollout at any given time, this label would only be present on the latest release within a deployment.
 
 * **Disabled** - Indicates whether the release has been marked as disabled or not, and therefore, is downloadable by end users. This property will only be displayed for releases that are actually disabled.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -107,7 +107,7 @@ If you need additional keys that can be used to authenticate against the CodePus
 code-push access-key add "VSTS Integration"
 ```
 
-By default, access keys expire in 60 days. You can specify a different expiry duration by using the `--maxAge` option and passing in a [human readable duration string](https://github.com/jkroso/parse-duration#parsestr) (e.g. "2d" => 2 days, "1h 15 min" => 1 hour and 15 minutes). For security, the key will only be shown once on creation, so remember to save it somewhere if needed!
+By default, access keys expire in 60 days. You can specify a different expiry duration by using the `--ttl` option and passing in a [human readable duration string](https://github.com/jkroso/parse-duration#parsestr) (e.g. "2d" => 2 days, "1h 15 min" => 1 hour and 15 minutes). For security, the key will only be shown once on creation, so remember to save it somewhere if needed!
 
 After creating the new key, you can specify its value using the `--accessKey` flag of the `login` command, which allows you to perform "headless" authentication, as opposed to launching a browser.
 
@@ -120,7 +120,7 @@ When logging in via this method, the access key will not be automatically invali
 Finally, if you need to change a key's name or expiry date, you can use the following command:
 
 ```
-code-push access-key edit <accessKeyName> --name "new name" --maxAge 10d
+code-push access-key edit <accessKeyName> --name "new name" --ttl 10d
 ```
 
 ## App Management

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -1,5 +1,6 @@
 ﻿export enum CommandType {
     accessKeyAdd,
+    accessKeyEdit,
     accessKeyList,
     accessKeyRemove,
     appAdd,
@@ -35,7 +36,14 @@ export interface ICommand {
 }
 
 export interface IAccessKeyAddCommand extends ICommand {
-    description: string;
+    friendlyName: string;
+    maxAge?: number;
+}
+
+export interface IAccessKeyEditCommand extends ICommand {
+    oldFriendlyName: string;
+    newFriendlyName?: string;
+    maxAge?: number;
 }
 
 export interface IAccessKeyListCommand extends ICommand {

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -1,6 +1,6 @@
 ﻿export enum CommandType {
     accessKeyAdd,
-    accessKeyEdit,
+    accessKeyPatch,
     accessKeyList,
     accessKeyRemove,
     appAdd,
@@ -42,7 +42,7 @@ export interface IAccessKeyAddCommand extends ICommand {
     ttl?: number;
 }
 
-export interface IAccessKeyEditCommand extends ICommand {
+export interface IAccessKeyPatchCommand extends ICommand {
     newName?: string;
     oldName: string;
     ttl?: number;

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -41,8 +41,8 @@ export interface IAccessKeyAddCommand extends ICommand {
 }
 
 export interface IAccessKeyEditCommand extends ICommand {
-    oldFriendlyName: string;
     newFriendlyName?: string;
+    oldFriendlyName: string;
     ttl?: number;
 }
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -37,13 +37,13 @@ export interface ICommand {
 
 export interface IAccessKeyAddCommand extends ICommand {
     friendlyName: string;
-    maxAge?: number;
+    ttl?: number;
 }
 
 export interface IAccessKeyEditCommand extends ICommand {
     oldFriendlyName: string;
     newFriendlyName?: string;
-    maxAge?: number;
+    ttl?: number;
 }
 
 export interface IAccessKeyListCommand extends ICommand {

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -28,6 +28,8 @@
     releaseCordova,
     releaseReact,
     rollback,
+    sessionList,
+    sessionRemove,
     whoami
 }
 
@@ -36,13 +38,13 @@ export interface ICommand {
 }
 
 export interface IAccessKeyAddCommand extends ICommand {
-    friendlyName: string;
+    name: string;
     ttl?: number;
 }
 
 export interface IAccessKeyEditCommand extends ICommand {
-    newFriendlyName?: string;
-    oldFriendlyName: string;
+    newName?: string;
+    oldName: string;
     ttl?: number;
 }
 
@@ -190,4 +192,12 @@ export interface IRollbackCommand extends ICommand {
     appName: string;
     deploymentName: string;
     targetRelease: string;
+}
+
+export interface ISessionListCommand extends ICommand {
+    format: string;
+}
+
+export interface ISessionRemoveCommand extends ICommand {
+    machineName: string;
 }

--- a/cli/definitions/parse-duration.d.ts
+++ b/cli/definitions/parse-duration.d.ts
@@ -1,0 +1,5 @@
+declare module "parse-duration" {
+    function parseDuration(duration: string): number;
+
+    export = parseDuration;
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push-cli",
-  "version": "1.11.0-beta",
+  "version": "1.12.0-beta",
   "description": "Management CLI for the CodePush service",
   "main": "script/cli.js",
   "scripts": {
@@ -28,11 +28,12 @@
     "base-64": "^0.1.0",
     "chalk": "^1.1.0",
     "cli-table": "^0.3.1",
-    "code-push": "1.9.1-beta",
+    "code-push": "1.10.0-beta",
     "email-validator": "^1.0.3",
     "gradle-to-js": "0.1.0",
     "moment": "^2.10.6",
     "opener": "^1.4.1",
+    "parse-duration": "0.1.1",
     "plist": "1.2.0",
     "progress": "^1.1.8",
     "prompt": "^0.2.14",

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -110,11 +110,11 @@ function accessKeyAdd(command: cli.IAccessKeyAddCommand): Promise<void> {
 }
 
 function accessKeyEdit(command: cli.IAccessKeyEditCommand): Promise<void> {
-    var willEditFriendlyName = isCommandOptionSpecified(command.newFriendlyName) && command.oldFriendlyName !== command.newFriendlyName;
-    var willEditTtl = isCommandOptionSpecified(command.ttl);
+    var willEditFriendlyName: boolean = isCommandOptionSpecified(command.newFriendlyName) && command.oldFriendlyName !== command.newFriendlyName;
+    var willEditTtl: boolean = isCommandOptionSpecified(command.ttl);
 
     if (!willEditFriendlyName && !willEditTtl) {
-        throw new Error("A new name or TTL must be provided.");
+        throw new Error("A new name and/or TTL must be provided.");
     }
 
     return sdk.editAccessKey(command.oldFriendlyName, command.newFriendlyName, command.ttl)
@@ -941,11 +941,11 @@ function printAccessKeys(format: string, keys: AccessKey[]): void {
         printTable(["Name", "Created", "Origin", "Expires"], (dataSource: any[]): void => {
             var now = new Date().getTime();
 
-            function isExpired(key: AccessKey) {
+            function isExpired(key: AccessKey): boolean {
                 return now >= key.expires;
             }
 
-            function keyToTableRow(key: AccessKey, dim: boolean) {
+            function keyToTableRow(key: AccessKey, dim: boolean): string[] {
                 var row: string[] = [
                     key.friendlyName,
                     key.createdTime ? formatDate(key.createdTime) : "",

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -101,28 +101,30 @@ export var confirm = (): Promise<boolean> => {
 }
 
 function accessKeyAdd(command: cli.IAccessKeyAddCommand): Promise<void> {
-    return sdk.addAccessKey(command.friendlyName, command.maxAge)
+    return sdk.addAccessKey(command.friendlyName, command.ttl)
         .then((accessKey: AccessKey) => {
-            log(`Successfully created a new access key "${command.friendlyName}": ${accessKey.name}\n(Expires: ${new Date(accessKey.expires).toString()})`);
+            log(`Successfully created a new access key "${command.friendlyName}": ${accessKey.name}`);
+            log(`(Expires: ${new Date(accessKey.expires).toString()})`);
+            log(`Please save this key as it will only be shown once!`);
         });
 }
 
 function accessKeyEdit(command: cli.IAccessKeyEditCommand): Promise<void> {
     var willEditFriendlyName = isCommandOptionSpecified(command.newFriendlyName) && command.oldFriendlyName !== command.newFriendlyName;
-    var willEditMaxAge = isCommandOptionSpecified(command.maxAge);
+    var willEditTtl = isCommandOptionSpecified(command.ttl);
 
-    if (!willEditFriendlyName && !willEditMaxAge) {
-        throw new Error("A new name or maxAge must be provided.");
+    if (!willEditFriendlyName && !willEditTtl) {
+        throw new Error("A new name or TTL must be provided.");
     }
 
-    return sdk.editAccessKey(command.oldFriendlyName, command.newFriendlyName, command.maxAge)
+    return sdk.editAccessKey(command.oldFriendlyName, command.newFriendlyName, command.ttl)
         .then((accessKey: AccessKey) => {
             var logMessage: string = "Successfully ";
             if (willEditFriendlyName) {
                 logMessage += `renamed the access key "${command.oldFriendlyName}" to "${command.newFriendlyName}"`;
             }
 
-            if (willEditMaxAge) {
+            if (willEditTtl) {
                 if (willEditFriendlyName) {
                     logMessage += ` and changed its expiry to ${new Date(accessKey.expires).toString()}`;
                 } else {
@@ -936,7 +938,7 @@ function printAccessKeys(format: string, keys: AccessKey[]): void {
     if (format === "json") {
         printJson(keys);
     } else if (format === "table") {
-        printTable(["Name", "Time Created", "Created From", "Expires"], (dataSource: any[]): void => {
+        printTable(["Name", "Created", "Origin", "Expires"], (dataSource: any[]): void => {
             var now = new Date().getTime();
 
             function isExpired(key: AccessKey) {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -108,8 +108,8 @@ function accessKeyAdd(command: cli.IAccessKeyAddCommand): Promise<void> {
 }
 
 function accessKeyEdit(command: cli.IAccessKeyEditCommand): Promise<void> {
-    var willEditFriendlyName = !!command.newFriendlyName && command.oldFriendlyName !== command.newFriendlyName;
-    var willEditMaxAge = command.maxAge !== null && command.maxAge !== undefined;
+    var willEditFriendlyName = isCommandOptionSpecified(command.newFriendlyName) && command.oldFriendlyName !== command.newFriendlyName;
+    var willEditMaxAge = isCommandOptionSpecified(command.maxAge);
 
     if (!willEditFriendlyName && !willEditMaxAge) {
         throw new Error("A new name or maxAge must be provided.");
@@ -1400,4 +1400,8 @@ function getProxy(proxy?: string, noProxy?: boolean): string {
     if (noProxy) return null;
     if (!proxy) return process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
     else return proxy;
+}
+
+function isCommandOptionSpecified(option: any): boolean {
+    return option !== undefined && option !== null;
 }

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -109,23 +109,23 @@ function accessKeyAdd(command: cli.IAccessKeyAddCommand): Promise<void> {
         });
 }
 
-function accessKeyEdit(command: cli.IAccessKeyEditCommand): Promise<void> {
-    var willEditName: boolean = isCommandOptionSpecified(command.newName) && command.oldName !== command.newName;
-    var willEditTtl: boolean = isCommandOptionSpecified(command.ttl);
+function accessKeyPatch(command: cli.IAccessKeyPatchCommand): Promise<void> {
+    var willUpdateName: boolean = isCommandOptionSpecified(command.newName) && command.oldName !== command.newName;
+    var willUpdateTtl: boolean = isCommandOptionSpecified(command.ttl);
 
-    if (!willEditName && !willEditTtl) {
+    if (!willUpdateName && !willUpdateTtl) {
         throw new Error("A new name and/or TTL must be provided.");
     }
 
-    return sdk.editAccessKey(command.oldName, command.newName, command.ttl)
+    return sdk.patchAccessKey(command.oldName, command.newName, command.ttl)
         .then((accessKey: AccessKey) => {
             var logMessage: string = "Successfully ";
-            if (willEditName) {
+            if (willUpdateName) {
                 logMessage += `renamed the access key "${command.oldName}" to "${command.newName}"`;
             }
 
-            if (willEditTtl) {
-                if (willEditName) {
+            if (willUpdateTtl) {
+                if (willUpdateName) {
                     logMessage += ` and changed its expiry to ${new Date(accessKey.expires).toString()}`;
                 } else {
                     logMessage += `changed the access key "${command.oldName}"'s expiry to ${new Date(accessKey.expires).toString()}`;
@@ -458,8 +458,8 @@ export function execute(command: cli.ICommand): Promise<void> {
                 case cli.CommandType.accessKeyAdd:
                     return accessKeyAdd(<cli.IAccessKeyAddCommand>command);
 
-                case cli.CommandType.accessKeyEdit:
-                    return accessKeyEdit(<cli.IAccessKeyEditCommand>command);
+                case cli.CommandType.accessKeyPatch:
+                    return accessKeyPatch(<cli.IAccessKeyPatchCommand>command);
 
                 case cli.CommandType.accessKeyList:
                     return accessKeyList(<cli.IAccessKeyListCommand>command);

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -42,7 +42,7 @@ function updateCheck(): void {
 
 function accessKeyAdd(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
-    yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <description>")
+    yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <accessKeyName>")
         .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
         .example("access-key " + commandName + " \"VSTS Integration\"", "Creates a new access key with the name \"VSO Integration\" which expires by default in 60 days")
         .example("access-key " + commandName + " \"One time key\" --maxAge 5m", "Creates a new access key with the name \"One time key\" which expires in 5 minutes")
@@ -53,8 +53,8 @@ function accessKeyAdd(commandName: string, yargs: yargs.Argv): void {
 
 function accessKeyEdit(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
-    yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <description>")
-        .demand(/*count*/ 3, /*max*/ 3)  // Require exactly two non-option arguments.
+    yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <accessKeyName>")
+        .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
         .example("access-key " + commandName + " \"Key for build server\" --name \"Key for CI machine\"", "Renames the access key named \"Key for build server\" to \"Key for CI machine\"")
         .example("access-key " + commandName + " \"Key for build server\" --maxAge 7d", "Edits the access key named \"Key for build server\" to expire in 7 days")
         .option("name", { default: null, demand: false, description: "New name for the access key", type: "string" })
@@ -75,7 +75,7 @@ function accessKeyList(commandName: string, yargs: yargs.Argv): void {
 
 function accessKeyRemove(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
-    yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <accessKey>")
+    yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <accessKeyName>")
         .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
         .example("access-key " + commandName + " 8d6513de-050c-4788-96f7-b2a50dd9684v", "Removes the \"8d6513de-050c-4788-96f7-b2a50dd9684v\" access key");
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -45,8 +45,8 @@ function accessKeyAdd(commandName: string, yargs: yargs.Argv): void {
     yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <accessKeyName>")
         .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
         .example("access-key " + commandName + " \"VSTS Integration\"", "Creates a new access key with the name \"VSO Integration\" which expires by default in 60 days")
-        .example("access-key " + commandName + " \"One time key\" --maxAge 5m", "Creates a new access key with the name \"One time key\" which expires in 5 minutes")
-        .option("maxAge", { default: null, demand: false, description: "A duration string specifying the time for which the access key remains valid for use", type: "string" });
+        .example("access-key " + commandName + " \"One time key\" --ttl 5m", "Creates a new access key with the name \"One time key\" which expires in 5 minutes")
+        .option("ttl", { default: null, demand: false, description: "A duration string specifying the time for which the access key remains valid for use", type: "string" });
 
     addCommonConfiguration(yargs);
 }
@@ -56,9 +56,9 @@ function accessKeyEdit(commandName: string, yargs: yargs.Argv): void {
     yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <accessKeyName>")
         .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
         .example("access-key " + commandName + " \"Key for build server\" --name \"Key for CI machine\"", "Renames the access key named \"Key for build server\" to \"Key for CI machine\"")
-        .example("access-key " + commandName + " \"Key for build server\" --maxAge 7d", "Edits the access key named \"Key for build server\" to expire in 7 days")
+        .example("access-key " + commandName + " \"Key for build server\" --ttl 7d", "Edits the access key named \"Key for build server\" to expire in 7 days")
         .option("name", { default: null, demand: false, description: "New name for the access key", type: "string" })
-        .option("maxAge", { default: null, demand: false, description: "Duration string specifying the time for which the access key remains valid for use", type: "string" });
+        .option("ttl", { default: null, demand: false, description: "Duration string specifying the time for which the access key remains valid for use", type: "string" });
     addCommonConfiguration(yargs);
 }
 
@@ -441,9 +441,9 @@ function createCommand(): cli.ICommand {
                             cmd = { type: cli.CommandType.accessKeyAdd };
                             var accessKeyAddCmd = <cli.IAccessKeyAddCommand>cmd;
                             accessKeyAddCmd.friendlyName = arg2;
-                            var maxAgeOption: string = argv["maxAge"];
-                            if (isDefined(maxAgeOption)) {
-                                accessKeyAddCmd.maxAge = parseDurationMilliseconds(maxAgeOption);
+                            var ttlOption: string = argv["ttl"];
+                            if (isDefined(ttlOption)) {
+                                accessKeyAddCmd.ttl = parseDurationMilliseconds(ttlOption);
                             }
                         }
                         break;
@@ -455,13 +455,13 @@ function createCommand(): cli.ICommand {
                             accessKeyEditCmd.oldFriendlyName = arg2;
 
                             var newFriendlyNameOption: string = argv["name"];
-                            var maxAgeOption: string = argv["maxAge"];
+                            var ttlOption: string = argv["ttl"];
                             if (isDefined(newFriendlyNameOption)) {
                                 accessKeyEditCmd.newFriendlyName = newFriendlyNameOption;
                             }
 
-                            if (isDefined(maxAgeOption)) {
-                                accessKeyEditCmd.maxAge = parseDurationMilliseconds(maxAgeOption);
+                            if (isDefined(ttlOption)) {
+                                accessKeyEditCmd.ttl = parseDurationMilliseconds(ttlOption);
                             }
                         }
                         break;

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -44,7 +44,7 @@ function accessKeyAdd(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
     yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <accessKeyName>")
         .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
-        .example("access-key " + commandName + " \"VSTS Integration\"", "Creates a new access key with the name \"VSO Integration\" which expires by default in 60 days")
+        .example("access-key " + commandName + " \"VSTS Integration\"", "Creates a new access key with the name \"VSTS Integration\" which expires by default in 60 days")
         .example("access-key " + commandName + " \"One time key\" --ttl 5m", "Creates a new access key with the name \"One time key\" which expires in 5 minutes")
         .option("ttl", { default: null, demand: false, description: "A duration string specifying the time for which the access key remains valid for use", type: "string" });
 
@@ -819,11 +819,11 @@ function getServerUrl(url: string): string {
     return url;
 }
 
-function isDefined(object: any) {
+function isDefined(object: any): boolean {
     return object !== undefined && object !== null;
 }
 
-function parseDurationMilliseconds(durationString: string) {
+function parseDurationMilliseconds(durationString: string): number {
     return Math.floor(parseDuration(durationString));
 }
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -51,7 +51,7 @@ function accessKeyAdd(commandName: string, yargs: yargs.Argv): void {
     addCommonConfiguration(yargs);
 }
 
-function accessKeyEdit(commandName: string, yargs: yargs.Argv): void {
+function accessKeyPatch(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
     yargs.usage(USAGE_PREFIX + " access-key " + commandName + " <accessKeyName>")
         .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
@@ -196,7 +196,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         yargs.usage(USAGE_PREFIX + " access-key <command>")
             .demand(/*count*/ 2, /*max*/ 2)  // Require exactly two non-option arguments.
             .command("add", "Create a new access key associated with your account", (yargs: yargs.Argv) => accessKeyAdd("add", yargs))
-            .command("edit", "Edit the name and expiry of an access key", (yargs: yargs.Argv) => accessKeyEdit("edit", yargs))
+            .command("patch", "Update the name and expiry of an access key", (yargs: yargs.Argv) => accessKeyPatch("patch", yargs))
             .command("remove", "Remove an existing access key", (yargs: yargs.Argv) => accessKeyRemove("remove", yargs))
             .command("rm", "Remove an existing access key", (yargs: yargs.Argv) => accessKeyRemove("rm", yargs))
             .command("list", "List the access keys associated with your account", (yargs: yargs.Argv) => accessKeyList("list", yargs))
@@ -480,20 +480,20 @@ function createCommand(): cli.ICommand {
                         }
                         break;
 
-                    case "edit":
+                    case "patch":
                         if (arg2) {
-                            cmd = { type: cli.CommandType.accessKeyEdit };
-                            var accessKeyEditCmd = <cli.IAccessKeyEditCommand>cmd;
-                            accessKeyEditCmd.oldName = arg2;
+                            cmd = { type: cli.CommandType.accessKeyPatch };
+                            var accessKeyPatchCmd = <cli.IAccessKeyPatchCommand>cmd;
+                            accessKeyPatchCmd.oldName = arg2;
 
                             var newNameOption: string = argv["name"];
                             var ttlOption: string = argv["ttl"];
                             if (isDefined(newNameOption)) {
-                                accessKeyEditCmd.newName = newNameOption;
+                                accessKeyPatchCmd.newName = newNameOption;
                             }
 
                             if (isDefined(ttlOption)) {
-                                accessKeyEditCmd.ttl = parseDurationMilliseconds(ttlOption);
+                                accessKeyPatchCmd.ttl = parseDurationMilliseconds(ttlOption);
                             }
                         }
                         break;

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -47,7 +47,7 @@ export class SdkStub {
         });
     }
 
-    public editAccessKey(oldName: string, newName?: string, newTtl?: number): Promise<codePush.AccessKey> {
+    public patchAccessKey(oldName: string, newName?: string, newTtl?: number): Promise<codePush.AccessKey> {
         return Q(<codePush.AccessKey>{
             createdTime: new Date().getTime(),
             name: newName,
@@ -315,9 +315,9 @@ describe("CLI", () => {
             });
     });
 
-    it("accessKeyEdit updates access key with new name", (done: MochaDone): void => {
-        var command: cli.IAccessKeyEditCommand = {
-            type: cli.CommandType.accessKeyEdit,
+    it("accessKeyPatch updates access key with new name", (done: MochaDone): void => {
+        var command: cli.IAccessKeyPatchCommand = {
+            type: cli.CommandType.accessKeyPatch,
             oldName: "Test name",
             newName: "Updated name"
         };
@@ -336,10 +336,10 @@ describe("CLI", () => {
     });
 
 
-    it("accessKeyEdit updates access key with new ttl", (done: MochaDone): void => {
+    it("accessKeyPatch updates access key with new ttl", (done: MochaDone): void => {
         var ttl = 10000;
-        var command: cli.IAccessKeyEditCommand = {
-            type: cli.CommandType.accessKeyEdit,
+        var command: cli.IAccessKeyPatchCommand = {
+            type: cli.CommandType.accessKeyPatch,
             oldName: "Test name",
             ttl
         };
@@ -357,10 +357,10 @@ describe("CLI", () => {
             });
     });
 
-    it("accessKeyEdit updates access key with new name and ttl", (done: MochaDone): void => {
+    it("accessKeyPatch updates access key with new name and ttl", (done: MochaDone): void => {
         var ttl = 10000;
-        var command: cli.IAccessKeyEditCommand = {
-            type: cli.CommandType.accessKeyEdit,
+        var command: cli.IAccessKeyPatchCommand = {
+            type: cli.CommandType.accessKeyPatch,
             oldName: "Test name",
             newName: "Updated name",
             ttl

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -37,22 +37,22 @@ export class SdkStub {
         });
     }
 
-    public addAccessKey(friendlyName: string, maxAge: number): Promise<codePush.AccessKey> {
+    public addAccessKey(friendlyName: string, ttl: number): Promise<codePush.AccessKey> {
         return Q(<codePush.AccessKey>{
             name: "key123",
             createdTime: new Date().getTime(),
             createdBy: os.hostname(),
             friendlyName,
-            expires: NOW + (isDefined(maxAge) ? maxAge : DEFAULT_ACCESS_KEY_MAX_AGE)
+            expires: NOW + (isDefined(ttl) ? ttl : DEFAULT_ACCESS_KEY_MAX_AGE)
         });
     }
 
-    public editAccessKey(oldFriendlyName: string, newFriendlyName?: string, newMaxAge?: number): Promise<codePush.AccessKey> {
+    public editAccessKey(oldFriendlyName: string, newFriendlyName?: string, newTtl?: number): Promise<codePush.AccessKey> {
         return Q(<codePush.AccessKey>{
             createdTime: new Date().getTime(),
             createdBy: os.hostname(),
             friendlyName: newFriendlyName,
-            expires: NOW + (isDefined(newMaxAge) ? newMaxAge : DEFAULT_ACCESS_KEY_MAX_AGE)
+            expires: NOW + (isDefined(newTtl) ? newTtl : DEFAULT_ACCESS_KEY_MAX_AGE)
         });
     }
 
@@ -250,7 +250,7 @@ describe("CLI", () => {
         sandbox.restore();
     });
 
-    it("accessKeyAdd creates access key with friendlyName and default maxAge", (done: MochaDone): void => {
+    it("accessKeyAdd creates access key with friendlyName and default ttl", (done: MochaDone): void => {
         var command: cli.IAccessKeyAddCommand = {
             type: cli.CommandType.accessKeyAdd,
             friendlyName: "Test name"
@@ -258,34 +258,50 @@ describe("CLI", () => {
 
         cmdexec.execute(command)
             .done((): void => {
-                sinon.assert.calledOnce(log);
+                sinon.assert.calledThrice(log);
                 assert.equal(log.args[0].length, 1);
 
                 var actual: string = log.args[0][0];
-                var expected = `Successfully created a new access key "Test name": key123\n(Expires: ${new Date(NOW + DEFAULT_ACCESS_KEY_MAX_AGE)})`;
-
+                var expected = `Successfully created a new access key "Test name": key123`;
                 assert.equal(actual, expected);
+
+                actual = log.args[1][0];
+                expected = `(Expires: ${new Date(NOW + DEFAULT_ACCESS_KEY_MAX_AGE)})`;
+                assert.equal(actual, expected);
+
+                actual = log.args[2][0];
+                expected = "Please save this key as it will only be shown once!";
+                assert.equal(actual, expected);
+
                 done();
             });
     });
 
-    it("accessKeyAdd creates access key with friendlyName and specified maxAge", (done: MochaDone): void => {
-        var maxAge = 10000;
+    it("accessKeyAdd creates access key with friendlyName and specified ttl", (done: MochaDone): void => {
+        var ttl = 10000;
         var command: cli.IAccessKeyAddCommand = {
             type: cli.CommandType.accessKeyAdd,
             friendlyName: "Test name",
-            maxAge
+            ttl
         };
 
         cmdexec.execute(command)
             .done((): void => {
-                sinon.assert.calledOnce(log);
+                sinon.assert.calledThrice(log);
                 assert.equal(log.args[0].length, 1);
 
                 var actual: string = log.args[0][0];
-                var expected = `Successfully created a new access key "Test name": key123\n(Expires: ${new Date(NOW + maxAge)})`;
-
+                var expected = `Successfully created a new access key "Test name": key123`;
                 assert.equal(actual, expected);
+
+                actual = log.args[1][0];
+                expected = `(Expires: ${new Date(NOW + ttl)})`;
+                assert.equal(actual, expected);
+
+                actual = log.args[2][0];
+                expected = "Please save this key as it will only be shown once!";
+                assert.equal(actual, expected);
+
                 done();
             });
     });
@@ -311,12 +327,12 @@ describe("CLI", () => {
     });
 
 
-    it("accessKeyEdit updates access key with new maxAge", (done: MochaDone): void => {
-        var maxAge = 10000;
+    it("accessKeyEdit updates access key with new ttl", (done: MochaDone): void => {
+        var ttl = 10000;
         var command: cli.IAccessKeyEditCommand = {
             type: cli.CommandType.accessKeyEdit,
             oldFriendlyName: "Test name",
-            maxAge
+            ttl
         };
 
         cmdexec.execute(command)
@@ -325,20 +341,20 @@ describe("CLI", () => {
                 assert.equal(log.args[0].length, 1);
 
                 var actual: string = log.args[0][0];
-                var expected = `Successfully changed the access key "Test name"'s expiry to ${new Date(NOW + maxAge).toString()}.`;
+                var expected = `Successfully changed the access key "Test name"'s expiry to ${new Date(NOW + ttl).toString()}.`;
 
                 assert.equal(actual, expected);
                 done();
             });
     });
 
-    it("accessKeyEdit updates access key with new friendlyName and maxAge", (done: MochaDone): void => {
-        var maxAge = 10000;
+    it("accessKeyEdit updates access key with new friendlyName and ttl", (done: MochaDone): void => {
+        var ttl = 10000;
         var command: cli.IAccessKeyEditCommand = {
             type: cli.CommandType.accessKeyEdit,
             oldFriendlyName: "Test name",
             newFriendlyName: "Updated name",
-            maxAge
+            ttl
         };
 
         cmdexec.execute(command)
@@ -347,7 +363,7 @@ describe("CLI", () => {
                 assert.equal(log.args[0].length, 1);
 
                 var actual: string = log.args[0][0];
-                var expected = `Successfully renamed the access key "Test name" to "Updated name" and changed its expiry to ${new Date(NOW + maxAge)}.`;
+                var expected = `Successfully renamed the access key "Test name" to "Updated name" and changed its expiry to ${new Date(NOW + ttl)}.`;
 
                 assert.equal(actual, expected);
                 done();

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -22,7 +22,7 @@ declare module "rest-definitions" {
 
     /*in*/
     export interface AccessKeyRequest extends AccessKeyBase {
-        maxAge?: number;
+        ttl?: number;
     }
 
     /*out*/

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -6,12 +6,23 @@ declare module "rest-definitions" {
      * - key: This property is the identifier for an object, with certain uniqueness constraints.
      */
 
-    /*inout*/
-    export interface AccessKey {
-        createdBy: string;
-        /*generated*/ createdTime?: number;
-        description?: string;
+    interface AccessKeyBase {
+        createdBy?: string;
+        /*legacy*/ description?: string;
+        /*key*/ friendlyName?: string;
         /*generated key*/ name?: string;
+    }
+
+    /*out*/
+    export interface AccessKey extends AccessKeyBase {
+        /*generated*/ createdTime?: number;
+        expires: number;
+        /*generated*/ isSession?: boolean;
+    }
+
+    /*in*/
+    export interface AccessKeyRequest extends AccessKeyBase {
+        maxAge?: number;
     }
 
     /*out*/
@@ -82,7 +93,7 @@ declare module "rest-definitions" {
         installed?: number;
     }
 
-    /*inout*/
+    /*out*/
     export interface Account {
         /*key*/ email: string;
         name: string;

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "1.9.2-beta",
+  "version": "1.10.0-beta",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -164,7 +164,7 @@ class AccountManager {
     }
 
 
-    public editAccessKey(oldName: string, newName?: string, ttl?: number): Promise<AccessKey> {
+    public patchAccessKey(oldName: string, newName?: string, ttl?: number): Promise<AccessKey> {
         var accessKeyRequest: AccessKeyRequest = {
             friendlyName: newName,
             ttl

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -90,7 +90,7 @@ class AccountManager {
         });
     }
 
-    public addAccessKey(friendlyName: string, maxAge?: number): Promise<AccessKey> {
+    public addAccessKey(friendlyName: string, ttl?: number): Promise<AccessKey> {
         if (!friendlyName) {
             throw new Error("A name must be specified when adding an access key.");
         }
@@ -98,7 +98,7 @@ class AccountManager {
         var accessKeyRequest: AccessKeyRequest = {
             createdBy: os.hostname(),
             friendlyName,
-            maxAge
+            ttl
         };
 
         return this.post(urlEncode `/accessKeys/`, JSON.stringify(accessKeyRequest), /*expectResponseBody=*/ true)
@@ -115,10 +115,10 @@ class AccountManager {
             .then((res: JsonResponse) => res.body.accessKeys);
     }
 
-    public editAccessKey(oldFriendlyName: string, newFriendlyName?: string, maxAge?: number): Promise<AccessKey> {
+    public editAccessKey(oldFriendlyName: string, newFriendlyName?: string, ttl?: number): Promise<AccessKey> {
         var accessKeyRequest: AccessKeyRequest = {
             friendlyName: newFriendlyName,
-            maxAge
+            ttl
         };
 
         return this.patch(urlEncode `/accessKeys/${oldFriendlyName}`, JSON.stringify(accessKeyRequest))

--- a/sdk/script/types.ts
+++ b/sdk/script/types.ts
@@ -1,8 +1,20 @@
-export { AccessKey, AccessKeyRequest, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Package, PackageInfo, UpdateMetrics } from "rest-definitions";
+export { AccessKeyRequest, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Package, PackageInfo, AccessKey as ServerAccessKey, UpdateMetrics } from "rest-definitions";
 
 export interface CodePushError {
     message?: string;
     statusCode?: number;
+}
+
+export interface AccessKey {
+    createdTime: number;
+    expires: number;
+    name: string;
+    key?: string;
+}
+
+export interface Session {
+    loggedInTime: number;
+    machineName: string;
 }
 
 export type Headers = { [headerName: string]: string };

--- a/sdk/script/types.ts
+++ b/sdk/script/types.ts
@@ -1,4 +1,4 @@
-export { AccessKey, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Package, PackageInfo, UpdateMetrics } from "rest-definitions";
+export { AccessKey, AccessKeyRequest, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Package, PackageInfo, UpdateMetrics } from "rest-definitions";
 
 export interface CodePushError {
     message?: string;

--- a/sdk/test/management-sdk.ts
+++ b/sdk/test/management-sdk.ts
@@ -63,6 +63,7 @@ describe("Management SDK", () => {
                     reject();
                 }, (error: any) => {
                     assert.equal(error.message, "Text");
+                    assert(error.statusCode);
                     resolve();
                 });
             });


### PR DESCRIPTION
This PR:

- Adds the ability to specify an expiry to access keys. If unspecified, keys will be created with a default expiry (60 days) on the server side.
   ```
$ code-push access-key add "Temporary key" --maxAge 5m

Successfully created a new access key "Temporary key": NnPx5-nmPnooZeMJygxmcqUd6wptVJx1XOClg
(Expires: Wed Jun 01 2016 16:59:19 GMT-0700 (PDT))
   ```
- Adds the ability to edit the name and expiry of your access keys.

   ```
$ code-push access-key edit "Old name" --name "New name" --maxAge "7h 15m"
Successfully renamed the access key "Old name" to "New name" and changed its expiry to Thu Jun 02 2016 00:21:43 GMT-0700 (PDT).
   ```

- Adds the ability to see the expiry of all your keys. In an upcoming server change, the server will no longer show the actual key strings anymore when the CLI tries to list access keys, the only time the actual key string will be displayed is during creation.

   ```
$ code-push access-key ls
   ```
![image](https://cloud.githubusercontent.com/assets/8598682/15729792/29566c1a-281c-11e6-9f4b-97409b10bed4.png)

@lostintangent 