### PR TITLE
code-push session ls + rm

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -38,13 +38,13 @@ export interface ICommand {
 }
 
 export interface IAccessKeyAddCommand extends ICommand {
-    friendlyName: string;
+    name: string;
     ttl?: number;
 }
 
 export interface IAccessKeyEditCommand extends ICommand {
-    oldFriendlyName: string;
-    newFriendlyName?: string;
+    oldName: string;
+    newName?: string;
     ttl?: number;
 }
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -28,6 +28,8 @@
     releaseCordova,
     releaseReact,
     rollback,
+    sessionList,
+    sessionRemove,
     whoami
 }
 
@@ -190,4 +192,12 @@ export interface IRollbackCommand extends ICommand {
     appName: string;
     deploymentName: string;
     targetRelease: string;
+}
+
+export interface ISessionListCommand extends ICommand {
+    format: string;
+}
+
+export interface ISessionRemoveCommand extends ICommand {
+    machineName: string;
 }

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -133,8 +133,8 @@ function sessionList(commandName: string, yargs: yargs.Argv): void {
     yargs.usage(USAGE_PREFIX + " session " + commandName + " [options]")
         .demand(/*count*/ 2, /*max*/ 2)  // Require exactly two non-option arguments.
         .example("session " + commandName, "Lists your sessions in tabular format")
-        .example("session " + commandName + " --format json", "Lists your sessions in JSON format")
-        .option("format", { default: "table", demand: false, description: "Output format to display your access keys with (\"json\" or \"table\")", type: "string" });
+        .example("session " + commandName + " --format json", "Lists your login sessions in JSON format")
+        .option("format", { default: "table", demand: false, description: "Output format to display your login sessions with (\"json\" or \"table\")", type: "string" });
 
     addCommonConfiguration(yargs);
 }
@@ -472,7 +472,7 @@ function createCommand(): cli.ICommand {
                         if (arg2) {
                             cmd = { type: cli.CommandType.accessKeyAdd };
                             var accessKeyAddCmd = <cli.IAccessKeyAddCommand>cmd;
-                            accessKeyAddCmd.friendlyName = arg2;
+                            accessKeyAddCmd.name = arg2;
                             var ttlOption: string = argv["ttl"];
                             if (isDefined(ttlOption)) {
                                 accessKeyAddCmd.ttl = parseDurationMilliseconds(ttlOption);
@@ -484,12 +484,12 @@ function createCommand(): cli.ICommand {
                         if (arg2) {
                             cmd = { type: cli.CommandType.accessKeyEdit };
                             var accessKeyEditCmd = <cli.IAccessKeyEditCommand>cmd;
-                            accessKeyEditCmd.oldFriendlyName = arg2;
+                            accessKeyEditCmd.oldName = arg2;
 
-                            var newFriendlyNameOption: string = argv["name"];
+                            var newNameOption: string = argv["name"];
                             var ttlOption: string = argv["ttl"];
-                            if (isDefined(newFriendlyNameOption)) {
-                                accessKeyEditCmd.newFriendlyName = newFriendlyNameOption;
+                            if (isDefined(newNameOption)) {
+                                accessKeyEditCmd.newName = newNameOption;
                             }
 
                             if (isDefined(ttlOption)) {

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -128,6 +128,26 @@ function removeCollaborator(commandName: string, yargs: yargs.Argv): void {
     addCommonConfiguration(yargs);
 }
 
+function sessionList(commandName: string, yargs: yargs.Argv): void {
+    isValidCommand = true;
+    yargs.usage(USAGE_PREFIX + " session " + commandName + " [options]")
+        .demand(/*count*/ 2, /*max*/ 2)  // Require exactly two non-option arguments.
+        .example("session " + commandName, "Lists your sessions in tabular format")
+        .example("session " + commandName + " --format json", "Lists your sessions in JSON format")
+        .option("format", { default: "table", demand: false, description: "Output format to display your access keys with (\"json\" or \"table\")", type: "string" });
+
+    addCommonConfiguration(yargs);
+}
+
+function sessionRemove(commandName: string, yargs: yargs.Argv): void {
+    isValidCommand = true;
+    yargs.usage(USAGE_PREFIX + " session " + commandName + " <machineName>")
+        .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
+        .example("session " + commandName + " \"John's PC\"", "Removes the existing login session from \"John's PC\"");
+
+    addCommonConfiguration(yargs);
+}
+
 function deploymentHistoryClear(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
     yargs.usage(USAGE_PREFIX + " deployment " + commandName + " <appName> <deploymentName>")
@@ -403,6 +423,18 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .example("rollback MyApp Production", "Performs a rollback on the \"Production\" deployment of \"MyApp\"")
             .example("rollback MyApp Production --targetRelease v4", "Performs a rollback on the \"Production\" deployment of \"MyApp\" to the v4 release")
             .option("targetRelease", { alias: "r", default: null, demand: false, description: "Label of the release to roll the specified deployment back to (e.g. v4). If omitted, the deployment will roll back to the previous release.", type: "string" });
+
+        addCommonConfiguration(yargs);
+    })
+    .command("session", "View and manage the current login sessions associated with your account", (yargs: yargs.Argv) => {
+        isValidCommandCategory = true;
+        yargs.usage(USAGE_PREFIX + " session <command>")
+            .demand(/*count*/ 2, /*max*/ 2)  // Require exactly two non-option arguments.
+            .command("remove", "Remove an existing login session", (yargs: yargs.Argv) => sessionRemove("remove", yargs))
+            .command("rm", "Remove an existing login session", (yargs: yargs.Argv) => sessionRemove("rm", yargs))
+            .command("list", "List the current login sessions associated with your account", (yargs: yargs.Argv) => sessionList("list", yargs))
+            .command("ls", "List the current login sessions associated with your account", (yargs: yargs.Argv) => sessionList("ls", yargs))
+            .check((argv: any, aliases: { [aliases: string]: string }): any => isValidCommand);  // Report unrecognized, non-hyphenated command category.
 
         addCommonConfiguration(yargs);
     })
@@ -776,6 +808,26 @@ function createCommand(): cli.ICommand {
                     rollbackCommand.appName = arg1;
                     rollbackCommand.deploymentName = arg2;
                     rollbackCommand.targetRelease = argv["targetRelease"];
+                }
+                break;
+
+            case "session":
+                switch (arg1) {
+                    case "list":
+                    case "ls":
+                        cmd = { type: cli.CommandType.sessionList };
+
+                        (<cli.ISessionListCommand>cmd).format = argv["format"];
+                        break;
+
+                    case "remove":
+                    case "rm":
+                        if (arg2) {
+                            cmd = { type: cli.CommandType.sessionRemove };
+
+                            (<cli.ISessionRemoveCommand>cmd).machineName = arg2;
+                        }
+                        break;
                 }
                 break;
 

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -6,7 +6,7 @@ import superagent = require("superagent");
 
 import Promise = Q.Promise;
 
-import { AccessKey, AccessKeyRequest, Account, App, CodePushError, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Headers, Package, PackageInfo, UpdateMetrics } from "./types";
+import { AccessKey, AccessKeyRequest, Account, App, CodePushError, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Headers, Package, PackageInfo, ServerAccessKey, Session, UpdateMetrics } from "./types";
 
 var superproxy = require("superagent-proxy");
 superproxy(superagent);
@@ -112,26 +112,62 @@ class AccountManager {
 
     public getAccessKeys(): Promise<AccessKey[]> {
         return this.get(urlEncode `/accessKeys`)
-            .then((res: JsonResponse) => res.body.accessKeys);
+            .then((res: JsonResponse) => {
+                var accessKeys: AccessKey[] = [];
+
+                res.body.accessKeys.forEach((serverAccessKey: ServerAccessKey) => {
+                    !serverAccessKey.isSession && accessKeys.push({
+                        createdTime: serverAccessKey.createdTime,
+                        expires: serverAccessKey.expires,
+                        name: serverAccessKey.friendlyName
+                    });
+                });
+
+                return accessKeys;
+            });
     }
 
-    public editAccessKey(oldFriendlyName: string, newFriendlyName?: string, ttl?: number): Promise<AccessKey> {
+    public getSessions(): Promise<Session[]> {
+        return this.get(urlEncode `/accessKeys`)
+            .then((res: JsonResponse) => {
+                // A machine name might be associated with multiple session keys,
+                // but we should only return one per machine name.
+                var sessionMap: { [machineName: string]: Session } = {};
+                var now: number = new Date().getTime();
+                res.body.accessKeys.forEach((serverAccessKey: ServerAccessKey) => {
+                    if (serverAccessKey.isSession && serverAccessKey.expires > now) {
+                        sessionMap[serverAccessKey.createdBy] = {
+                            loggedInTime: serverAccessKey.createdTime,
+                            machineName: serverAccessKey.createdBy
+                        };
+                    }
+                });
+
+                var sessions: Session[] = Object.keys(sessionMap)
+                    .map((machineName: string) => sessionMap[machineName]);
+
+                return sessions;
+            });
+    }
+
+
+    public editAccessKey(oldName: string, newName?: string, ttl?: number): Promise<AccessKey> {
         var accessKeyRequest: AccessKeyRequest = {
-            friendlyName: newFriendlyName,
+            friendlyName: newName,
             ttl
         };
 
-        return this.patch(urlEncode `/accessKeys/${oldFriendlyName}`, JSON.stringify(accessKeyRequest))
+        return this.patch(urlEncode `/accessKeys/${oldName}`, JSON.stringify(accessKeyRequest))
             .then((res: JsonResponse) => res.body.accessKey);
     }
 
-    public removeAccessKey(accessKey: string): Promise<void> {
-        return this.del(urlEncode `/accessKeys/${accessKey}`)
+    public removeAccessKey(name: string): Promise<void> {
+        return this.del(urlEncode `/accessKeys/${name}`)
             .then(() => null);
     }
 
-    public removeSessions(createdBy: string): Promise<void> {
-        return this.del(urlEncode `/sessions/${createdBy}`)
+    public removeSession(machineName: string): Promise<void> {
+        return this.del(urlEncode `/sessions/${machineName}`)
             .then(() => null);
     }
 

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -130,6 +130,11 @@ class AccountManager {
             .then(() => null);
     }
 
+    public removeSessions(createdBy: string): Promise<void> {
+        return this.del(urlEncode `/sessions/${createdBy}`)
+            .then(() => null);
+    }
+
     // Account
     public getAccountInfo(): Promise<Account> {
         return this.get(urlEncode `/account`)
@@ -322,7 +327,11 @@ class AccountManager {
 
             request.end((err: any, res: superagent.Response) => {
                 if (err) {
-                    reject(<CodePushError>{ message: this.getErrorMessage(err, res) });
+                    reject(<CodePushError>{
+                        message: this.getErrorMessage(err, res),
+                        statusCode: res.status
+                    });
+
                     return;
                 }
 

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -102,12 +102,25 @@ class AccountManager {
         };
 
         return this.post(urlEncode `/accessKeys/`, JSON.stringify(accessKeyRequest), /*expectResponseBody=*/ true)
-            .then((response: JsonResponse) => response.body.accessKey);
+            .then((response: JsonResponse) => {
+                return {
+                    createdTime: response.body.accessKey.createdTime,
+                    expires: response.body.accessKey.expires,
+                    key: response.body.accessKey.name,
+                    name: response.body.accessKey.friendlyName
+                };
+            });
     }
 
     public getAccessKey(accessKeyName: string): Promise<AccessKey> {
         return this.get(urlEncode `/accessKeys/${accessKeyName}`)
-            .then((res: JsonResponse) => res.body.accessKey);
+            .then((res: JsonResponse) => {
+                return {
+                    createdTime: res.body.accessKey.createdTime,
+                    expires: res.body.accessKey.expires,
+                    name: res.body.accessKey.friendlyName,
+                };
+            });
     }
 
     public getAccessKeys(): Promise<AccessKey[]> {
@@ -158,7 +171,13 @@ class AccountManager {
         };
 
         return this.patch(urlEncode `/accessKeys/${oldName}`, JSON.stringify(accessKeyRequest))
-            .then((res: JsonResponse) => res.body.accessKey);
+            .then((res: JsonResponse) => {
+                return {
+                    createdTime: res.body.accessKey.createdTime,
+                    expires: res.body.accessKey.expires,
+                    name: res.body.accessKey.friendlyName,
+                };
+            });
     }
 
     public removeAccessKey(name: string): Promise<void> {

--- a/sdk/script/types.ts
+++ b/sdk/script/types.ts
@@ -1,8 +1,20 @@
-export { AccessKey, AccessKeyRequest, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Package, PackageInfo, UpdateMetrics } from "rest-definitions";
+export { AccessKeyRequest, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Package, PackageInfo, AccessKey as ServerAccessKey, UpdateMetrics } from "rest-definitions";
 
 export interface CodePushError {
     message?: string;
     statusCode?: number;
+}
+
+export interface AccessKey {
+    createdTime: number;
+    expires: number;
+    name: string;
+    key?: string;
+}
+
+export interface Session {
+    loggedInTime: number;
+    machineName: string;
 }
 
 export type Headers = { [headerName: string]: string };

--- a/sdk/test/management-sdk.ts
+++ b/sdk/test/management-sdk.ts
@@ -63,6 +63,7 @@ describe("Management SDK", () => {
                     reject();
                 }, (error: any) => {
                     assert.equal(error.message, "Text");
+                    assert(error.statusCode);
                     resolve();
                 });
             });


### PR DESCRIPTION
(Merging into "access-key-changes" branch)

This PR:

- Adds the ability to list sessions. 
  - `access-key ls` will only show access keys that are created via `access-key add`, and will show the name of the key, the time it was created, and the expiry.
  - `session ls` will only show keys that are created via the normal login process, and will show the name of the machine associated with the session and the time it was created.
- Adds the ability to remove sessions by "machine name"
- Automatically removes the cached credentials on the temp directory if they are no longer valid (expired, etc).
- Fixed a test with the Management SDK - the statusCode was not being propagated in the returned error. Hilariously, the "methods reject the promise with status code info when an error occurs" test did not actually check the status code and was blissfully passing all this time :)
- Added new TypeScript definitions distinguishing "AccessKey"s from "Session"s
- Got rid of the "friendlyName" concept and simply replaced them with "name" globally

@lostintangent 