### PR TITLE
Adding debug command

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -11,6 +11,7 @@
     collaboratorAdd,
     collaboratorList,
     collaboratorRemove,
+    debug,
     deploymentAdd,
     deploymentHistory,
     deploymentHistoryClear,
@@ -91,6 +92,11 @@ export interface ICollaboratorListCommand extends ICommand {
 export interface ICollaboratorRemoveCommand extends ICommand {
     appName: string;
     email: string;
+}
+
+
+export interface IDebugCommand extends ICommand {
+    platform: string;
 }
 
 export interface IDeploymentAddCommand extends ICommand {

--- a/cli/package.json
+++ b/cli/package.json
@@ -41,6 +41,7 @@
     "recursive-fs": "0.1.4",
     "rimraf": "^2.5.1",
     "semver": "4.3.6",
+    "simctl": "0.0.9",
     "slash": "1.0.0",
     "update-notifier": "^0.5.0",
     "which": "^1.2.7",

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -17,11 +17,14 @@ import * as Q from "q";
 import * as recursiveFs from "recursive-fs";
 var rimraf = require("rimraf");
 import * as semver from "semver";
+var simctl = require("simctl");
 import slash = require("slash");
 var Table = require("cli-table");
 import * as yazl from "yazl";
 var which = require("which");
 import wordwrap = require("wordwrap");
+
+var debugCommand = require("./commands/debug");
 
 import * as cli from "../definitions/cli";
 import { AccessKey, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Headers, Package, PackageInfo, Session, UpdateMetrics } from "code-push/script/types";
@@ -490,6 +493,9 @@ export function execute(command: cli.ICommand): Promise<void> {
 
                 case cli.CommandType.collaboratorRemove:
                     return removeCollaborator(<cli.ICollaboratorRemoveCommand>command);
+
+                case cli.CommandType.debug:
+                    return debugCommand(<cli.IDebugCommand>command);
 
                 case cli.CommandType.deploymentAdd:
                     return deploymentAdd(<cli.IDeploymentAddCommand>command);

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -24,12 +24,11 @@ import * as yazl from "yazl";
 var which = require("which");
 import wordwrap = require("wordwrap");
 
-var debugCommand = require("./commands/debug");
-
 import * as cli from "../definitions/cli";
 import { AccessKey, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Headers, Package, PackageInfo, Session, UpdateMetrics } from "code-push/script/types";
 
 var configFilePath: string = path.join(process.env.LOCALAPPDATA || process.env.HOME, ".code-push.config");
+var debugCommand = require("./commands/debug");
 var emailValidator = require("email-validator");
 var packageJson = require("../package.json");
 var parseXml = Q.denodeify(require("xml2js").parseString);

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -4,6 +4,7 @@ import AccountManager = require("code-push");
 import * as base64 from "base-64";
 import * as chalk from "chalk";
 var childProcess = require("child_process");
+import debugCommand from "./commands/debug";
 import * as fs from "fs";
 var g2js = require("gradle-to-js/lib/parser");
 import * as moment from "moment";
@@ -23,12 +24,10 @@ var Table = require("cli-table");
 import * as yazl from "yazl";
 var which = require("which");
 import wordwrap = require("wordwrap");
-
 import * as cli from "../definitions/cli";
 import { AccessKey, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Headers, Package, PackageInfo, Session, UpdateMetrics } from "code-push/script/types";
 
 var configFilePath: string = path.join(process.env.LOCALAPPDATA || process.env.HOME, ".code-push.config");
-var debugCommand = require("./commands/debug");
 var emailValidator = require("email-validator");
 var packageJson = require("../package.json");
 var parseXml = Q.denodeify(require("xml2js").parseString);

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -260,6 +260,16 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
 
         addCommonConfiguration(yargs);
     })
+    .command("debug", "View the CodePush debug logs for a running app", (yargs: yargs.Argv) => {
+        isValidCommandCategory = true;
+        isValidCommand = true;
+        yargs.usage(USAGE_PREFIX + " debug <platform>")
+            .demand(/*count*/ 2, /*max*/ 2)
+            .example("debug android", "View the CodePush debug logs for an Android emulator or device")
+            .example("debug ios", "View the CodePush debug logs for the iOS simulator");
+
+        addCommonConfiguration(yargs);
+    })
     .command("deployment", "View and manage your app deployments", (yargs: yargs.Argv) => {
         isValidCommandCategory = true;
         yargs.usage(USAGE_PREFIX + " deployment <command>")
@@ -597,6 +607,15 @@ function createCommand(): cli.ICommand {
                         }
                         break;
                 }
+                break;
+
+            
+            case "debug":
+                cmd = { type: cli.CommandType.debug };
+
+                var debugCommand = <cli.IDebugCommand>cmd;
+                debugCommand.platform = arg1;
+
                 break;
 
             case "deployment":

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -611,10 +611,10 @@ function createCommand(): cli.ICommand {
 
             
             case "debug":
-                cmd = { type: cli.CommandType.debug };
-
-                var debugCommand = <cli.IDebugCommand>cmd;
-                debugCommand.platform = arg1;
+                cmd = <cli.IDebugCommand>{
+                    type: cli.CommandType.debug,
+                    platform: arg1
+                };
 
                 break;
 

--- a/cli/script/commands/debug.ts
+++ b/cli/script/commands/debug.ts
@@ -82,7 +82,7 @@ const debugPlatforms: any = {
     ios: new iOSDebugPlatform()
 };
 
-module.exports = (command: cli.IDebugCommand): Q.Promise<void> => {
+export default function (command: cli.IDebugCommand): Q.Promise<void> {
     return Q.Promise<void>((resolve, reject) => {
         const platform: string = command.platform.toLowerCase();
         const debugPlatform: IDebugPlatform = debugPlatforms[platform];

--- a/cli/script/commands/debug.ts
+++ b/cli/script/commands/debug.ts
@@ -12,7 +12,7 @@ interface IDebugPlatform {
 }
 
 class AndroidDebugPlatform implements IDebugPlatform {
-    getLogProcess() {
+    public getLogProcess(): any {
         try {
             which.sync("adb");
         } catch (e) {
@@ -31,7 +31,7 @@ class AndroidDebugPlatform implements IDebugPlatform {
     //
     // List of devices attached
     // emulator-5554	device
-    private isDeviceAvailable() {
+    private isDeviceAvailable(): boolean {
         const output = childProcess.execSync("adb devices").toString();
         return output.search(/^[\w-]+\s+device$/mi) > -1;
     }
@@ -40,21 +40,21 @@ class AndroidDebugPlatform implements IDebugPlatform {
 class iOSDebugPlatform implements IDebugPlatform {
     private getSimulatorID(): string {
         const output: any = simctl.list({ devices: true, silent: true });
-        const simulators = output.json.devices
-                            .map((platform: any) => platform.devices)
-                            .reduce((prev: any, next: any) => prev.concat(next))
-                            .filter((device: any) => device.state === "Booted")
-                            .map((device: any) => device.id);
+        const simulators: string[] = output.json.devices
+                                        .map((platform: any) => platform.devices)
+                                        .reduce((prev: any, next: any) => prev.concat(next))
+                                        .filter((device: any) => device.state === "Booted")
+                                        .map((device: any) => device.id);
 
         return simulators[0];
     }
 
-    getLogProcess() {
+    public getLogProcess(): any {
         if (process.platform !== "darwin") {
             throw new Error("iOS debug logs can only be viewed on OS X.");
         }
 
-        const simulatorID = this.getSimulatorID();
+        const simulatorID: string = this.getSimulatorID();
         if (!simulatorID) {
             throw new Error("No iOS simulators found. Re-run this command after starting one."); 
         }
@@ -68,13 +68,13 @@ const logMessagePrefix = "[CodePush] ";
 function processLogData(logData: Buffer) {
     const content = logData.toString()
     content.split("\n")
-        .filter((line) => line.indexOf(logMessagePrefix) > -1)
-        .map((line) => {
+        .filter((line: string) => line.indexOf(logMessagePrefix) > -1)
+        .map((line: string) => {
             const timeStamp = moment().format("hh:mm:ss");
             const message = line.substring(line.indexOf(logMessagePrefix) + logMessagePrefix.length);
             return `[${timeStamp}] ${message}`;
         })
-        .forEach((line) => console.log(line));
+        .forEach((line: string) => console.log(line));
 }
 
 const debugPlatforms: any = {

--- a/cli/script/commands/debug.ts
+++ b/cli/script/commands/debug.ts
@@ -19,7 +19,7 @@ class AndroidDebugPlatform implements IDebugPlatform {
             throw new Error("ADB command not found. Please ensure it is installed and available on your path.");
         }
 
-        if (!this.isAndroidDeviceAvailable()) {
+        if (!this.isDeviceAvailable()) {
             throw new Error("No Android devices found. Re-run this command after starting one.");
         }
 
@@ -27,18 +27,18 @@ class AndroidDebugPlatform implements IDebugPlatform {
     }
 
     // The following is an example of what the output looks
-    // like for when running the "adb devices" command.
+    // like when running the "adb devices" command.
     //
     // List of devices attached
     // emulator-5554	device
-    private isAndroidDeviceAvailable() {
+    private isDeviceAvailable() {
         const output = childProcess.execSync("adb devices").toString();
         return output.search(/^[\w-]+\s+device$/mi) > -1;
     }
 }
 
 class iOSDebugPlatform implements IDebugPlatform {
-    private getIOSSimulatorID(): string {
+    private getSimulatorID(): string {
         const output: any = simctl.list({ devices: true, silent: true });
         const simulators = output.json.devices
                             .map((platform: any) => platform.devices)
@@ -54,7 +54,7 @@ class iOSDebugPlatform implements IDebugPlatform {
             throw new Error("iOS debug logs can only be viewed on OS X.");
         }
 
-        const simulatorID = this.getIOSSimulatorID();
+        const simulatorID = this.getSimulatorID();
         if (!simulatorID) {
             throw new Error("No iOS simulators found. Re-run this command after starting one."); 
         }

--- a/cli/script/commands/debug.ts
+++ b/cli/script/commands/debug.ts
@@ -94,6 +94,8 @@ export default function (command: cli.IDebugCommand): Q.Promise<void> {
 
         try {
             const logProcess = debugPlatform.getLogProcess();
+            console.log(`Listening for ${platform} debug logs (Press CTRL+C to exit)`);
+
             logProcess.stdout.on("data", processLogData);
             logProcess.stderr.on("data", reject);
 

--- a/cli/script/commands/debug.ts
+++ b/cli/script/commands/debug.ts
@@ -1,0 +1,105 @@
+import * as childProcess from "child_process";
+import * as cli from "../../definitions/cli";
+import * as moment from "moment";
+import * as path from "path";
+import * as Q from "q";
+
+const simctl = require("simctl");
+const which = require("which");
+
+interface IDebugPlatform {
+    getLogProcess(): any;
+}
+
+class AndroidDebugPlatform implements IDebugPlatform {
+    getLogProcess() {
+        try {
+            which.sync("adb");
+        } catch (e) {
+            throw new Error("ADB command not found. Please ensure it is installed and available on your path.");
+        }
+
+        if (!this.isAndroidDeviceAvailable()) {
+            throw new Error("No Android devices found. Re-run this command after starting one.");
+        }
+
+        return childProcess.spawn("adb", ["logcat"]);
+    }
+
+    // The following is an example of what the output looks
+    // like for when running the "adb devices" command.
+    //
+    // List of devices attached
+    // emulator-5554	device
+    private isAndroidDeviceAvailable() {
+        const output = childProcess.execSync("adb devices").toString();
+        return output.search(/^[\w-]+\s+device$/mi) > -1;
+    }
+}
+
+class iOSDebugPlatform implements IDebugPlatform {
+    private getIOSSimulatorID(): string {
+        const output: any = simctl.list({ devices: true, silent: true });
+        const simulators = output.json.devices
+                            .map((platform: any) => platform.devices)
+                            .reduce((prev: any, next: any) => prev.concat(next))
+                            .filter((device: any) => device.state === "Booted")
+                            .map((device: any) => device.id);
+
+        return simulators[0];
+    }
+
+    getLogProcess() {
+        if (process.platform !== "darwin") {
+            throw new Error("iOS debug logs can only be viewed on OS X.");
+        }
+
+        const simulatorID = this.getIOSSimulatorID();
+        if (!simulatorID) {
+            throw new Error("No iOS simulators found. Re-run this command after starting one."); 
+        }
+
+        const logFilePath: string = path.join(process.env.HOME, "Library/Logs/CoreSimulator", simulatorID, "system.log");
+        return childProcess.spawn("tail", ["-f", logFilePath]);
+    }
+}
+
+const logMessagePrefix = "[CodePush] ";
+function processLogData(logData: Buffer) {
+    const content = logData.toString()
+    content.split("\n")
+        .filter((line) => line.indexOf(logMessagePrefix) > -1)
+        .map((line) => {
+            const timeStamp = moment().format("hh:mm:ss");
+            const message = line.substring(line.indexOf(logMessagePrefix) + logMessagePrefix.length);
+            return `[${timeStamp}] ${message}`;
+        })
+        .forEach((line) => console.log(line));
+}
+
+const debugPlatforms: any = {
+    android: new AndroidDebugPlatform(),
+    ios: new iOSDebugPlatform()
+};
+
+module.exports = (command: cli.IDebugCommand): Q.Promise<void> => {
+    return Q.Promise<void>((resolve, reject) => {
+        const platform: string = command.platform.toLowerCase();
+        const debugPlatform: IDebugPlatform = debugPlatforms[platform];
+
+        if (!debugPlatform) {
+            const availablePlatforms = Object.getOwnPropertyNames(debugPlatforms);
+            return reject(new Error(`"${platform}" is an unsupported platform. Available options are ${availablePlatforms.join(", ")}.`));
+        }
+
+        try {
+            const logProcess = debugPlatform.getLogProcess();
+            logProcess.stdout.on("data", processLogData);
+            logProcess.stderr.on("data", reject);
+
+            logProcess.on("close", resolve); 
+        } catch (e) {
+            reject(e);
+        }
+    }); 
+};


### PR DESCRIPTION
This PR introduces a new `debug` command to the CLI which allows you to easily view the CodePush debug logs for a running Android or iOS app. This provides an easier on-boarding experience when users need to diagnose what may be going wrong with our plugin, and doesn't require them to use (or learn) a separate tool in order to do it (e.g. Chrome console, OS X console, Xcode console, ADB logcat).

<img width="483" alt="screen shot 2016-06-14 at 10 32 00 am" src="https://cloud.githubusercontent.com/assets/116461/16052912/4785774a-321b-11e6-9a40-a15cf04dd350.png">

*NOTE: This doesn't currently support iOS devices, but we can add that later.*