### PR TITLE
Stripping Android Cordova suffix

### DIFF
--- a/cli/script/commands/debug.ts
+++ b/cli/script/commands/debug.ts
@@ -9,6 +9,7 @@ const which = require("which");
 
 interface IDebugPlatform {
     getLogProcess(): any;
+    normalizeLogMessage(message: string): string;
 }
 
 class AndroidDebugPlatform implements IDebugPlatform {
@@ -34,6 +35,17 @@ class AndroidDebugPlatform implements IDebugPlatform {
     private isDeviceAvailable(): boolean {
         const output = childProcess.execSync("adb devices").toString();
         return output.search(/^[\w-]+\s+device$/mi) > -1;
+    }
+
+    public normalizeLogMessage(message: string): string {
+        // Check to see whether the message includes the source URL
+        // suffix, and if so, strip it. This can occur in Android Cordova apps.
+        const sourceURLIndex: number = message.indexOf("\", source: file:///");
+        if (~sourceURLIndex) {
+            return message.substring(0, sourceURLIndex);
+        } else {
+            return message;
+        }
     }
 }
 
@@ -62,6 +74,10 @@ class iOSDebugPlatform implements IDebugPlatform {
         const logFilePath: string = path.join(process.env.HOME, "Library/Logs/CoreSimulator", simulatorID, "system.log");
         return childProcess.spawn("tail", ["-f", logFilePath]);
     }
+
+    public normalizeLogMessage(message: string): string {
+        return message;
+    }
 }
 
 const logMessagePrefix = "[CodePush] ";
@@ -70,8 +86,15 @@ function processLogData(logData: Buffer) {
     content.split("\n")
         .filter((line: string) => line.indexOf(logMessagePrefix) > -1)
         .map((line: string) => {
-            const timeStamp = moment().format("hh:mm:ss");
+            // Allow the current platform
+            // to normalize the message first.
+            line = this.normalizeLogMessage(line);
+
+            // Strip the CodePush-specific, platform agnostic
+            // log message prefix that is added to each entry.
             const message = line.substring(line.indexOf(logMessagePrefix) + logMessagePrefix.length);
+            
+            const timeStamp = moment().format("hh:mm:ss");
             return `[${timeStamp}] ${message}`;
         })
         .forEach((line: string) => console.log(line));
@@ -96,7 +119,7 @@ export default function (command: cli.IDebugCommand): Q.Promise<void> {
             const logProcess = debugPlatform.getLogProcess();
             console.log(`Listening for ${platform} debug logs (Press CTRL+C to exit)`);
 
-            logProcess.stdout.on("data", processLogData);
+            logProcess.stdout.on("data", processLogData.bind(debugPlatform));
             logProcess.stderr.on("data", reject);
 
             logProcess.on("close", resolve); 


### PR DESCRIPTION
In my attempt to display a platform-agnostic view of the CodePush logs via the new `code-push debug` command, I forgot to strip the source URL suffix that the Cordova Android platform adds to each log message. This PR simply introduces a new capability to each debug platform that allows them to perform any platform-specific processing on each log, which allows them to "clean" them up before being displayed to the end user. The beauty of this is that all of the logs look the same, regardless if its Cordova, React Native, Android or iOS.