### PR TITLE
release-react plist customizations

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -191,6 +191,8 @@ export interface IReleaseReactCommand extends IReleaseBaseCommand {
     development?: boolean;
     entryFile?: string;
     platform: string;
+    plistFile?: string;
+    plistFilePrefix?: string;
     sourcemapOutput?: string;
 }
 

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -867,10 +867,11 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string, 
         };        
     
         let resolvedPlistFile: string = options.plistFile;
-        if (resolvedPlistFile) {
-            if (!fileExistsPredicate(resolvedPlistFile)) {
-                throw new Error("The specified plist file doesn't exist. Please check that the provided path is correct.");
-            }
+
+        // If a plist file path is explicitly provided, then we don't
+        // need to attempt to "resolve" it within the well-known locations.
+        if (resolvedPlistFile && !fileExistsPredicate(resolvedPlistFile)) {
+            throw new Error("The specified plist file doesn't exist. Please check that the provided path is correct.");
         } else {
             const iOSDirectory: string = "ios";
             const plistFileName = `${options.plistFilePrefix || ""}Info.plist`;
@@ -880,7 +881,7 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string, 
                 path.join(iOSDirectory, plistFileName)
             ];
             
-            resolvedPlistFile = (<any>knownLocations).find((fileExistsPredicate));
+            resolvedPlistFile = (<any>knownLocations).find(fileExistsPredicate);
 
             if (!resolvedPlistFile) {
                 throw new Error(`Unable to find either of the following plist files in order to infer your app's binary version: "${knownLocations.join("\", \"")}".`);

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -861,7 +861,7 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string, 
     const missingPatchVersionRegex: RegExp = /^\d+\.\d+$/;
 
     if (platform === "ios") {
-        const fileExistsPredicate = (file: string): boolean => {
+        const fileExists = (file: string): boolean => {
             try { return fs.statSync(file).isFile() }
             catch (e) { return false }
         };        
@@ -870,7 +870,7 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string, 
 
         // If a plist file path is explicitly provided, then we don't
         // need to attempt to "resolve" it within the well-known locations.
-        if (resolvedPlistFile && !fileExistsPredicate(resolvedPlistFile)) {
+        if (resolvedPlistFile && !fileExists(resolvedPlistFile)) {
             throw new Error("The specified plist file doesn't exist. Please check that the provided path is correct.");
         } else {
             const iOSDirectory: string = "ios";
@@ -881,7 +881,7 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string, 
                 path.join(iOSDirectory, plistFileName)
             ];
             
-            resolvedPlistFile = (<any>knownLocations).find(fileExistsPredicate);
+            resolvedPlistFile = (<any>knownLocations).find(fileExists);
 
             if (!resolvedPlistFile) {
                 throw new Error(`Unable to find either of the following plist files in order to infer your app's binary version: "${knownLocations.join("\", \"")}".`);
@@ -903,7 +903,7 @@ function getReactNativeProjectAppVersion(platform: string, projectName: string, 
                 throw new Error(`The "CFBundleShortVersionString" key in "${resolvedPlistFile}" needs to have at least a major and minor version, for example "2.0" or "1.0.3".`);
             }
         } else {
-            throw new Error(`The "CFBundleShortVersionString" key does not exist in "${resolvedPlistFile}" file..`);
+            throw new Error(`The "CFBundleShortVersionString" key does not exist in "${resolvedPlistFile}" file.`);
         }
     } else if (platform === "android") {
         var buildGradlePath: string = path.join("android", "app", "build.gradle");

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -420,6 +420,8 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("disabled", { alias: "x", default: false, demand: false, description: "Specifies whether this release should be immediately downloadable", type: "boolean" })
             .option("entryFile", { alias: "e", default: null, demand: false, description: "Path to the app's entry Javascript file. If omitted, \"index.<platform>.js\" and then \"index.js\" will be used (if they exist)", type: "string" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Specifies whether this release should be considered mandatory", type: "boolean" })
+            .option("plistFile", { alias: "p", default: null, demand: false, description: "Path to the plist file which specifies the binary version you want to target this release at (iOS only)." })
+            .option("plistFilePrefix", { alias: "pre", default: null, demand: false, description: "Prefix to append to the file name when attempting to find your app's Info.plist file (iOS only)." })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("sourcemapOutput", { alias: "s", default: null, demand: false, description: "Path to where the sourcemap for the resulting bundle should be written. If omitted, a sourcemap will not be generated.", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the \"Info.plist\" (iOS), \"build.gradle\" (Android) or \"Package.appxmanifest\" (Windows) files.", type: "string" })
@@ -805,6 +807,7 @@ function createCommand(): cli.ICommand {
                     releaseReactCommand.appName = arg1;
                     releaseReactCommand.platform = arg2;
 
+                    releaseReactCommand.appStoreVersion = argv["targetBinaryVersion"];                    
                     releaseReactCommand.bundleName = argv["bundleName"];
                     releaseReactCommand.deploymentName = argv["deploymentName"];
                     releaseReactCommand.disabled = argv["disabled"];
@@ -812,9 +815,10 @@ function createCommand(): cli.ICommand {
                     releaseReactCommand.development = argv["development"];
                     releaseReactCommand.entryFile = argv["entryFile"];
                     releaseReactCommand.mandatory = argv["mandatory"];
+                    releaseReactCommand.plistFile = argv["plistFile"];  
+                    releaseReactCommand.plistFilePrefix = argv["plistFilePrefix"];                    
                     releaseReactCommand.rollout = getRolloutValue(argv["rollout"]);
                     releaseReactCommand.sourcemapOutput = argv["sourcemapOutput"];
-                    releaseReactCommand.appStoreVersion = argv["targetBinaryVersion"];
                 }
                 break;
 


### PR DESCRIPTION
This addresses #207 by adding two new optional parameters to the `release-react` command: `plistFile` and `plistFilePrefix`. The latter allows simply augmenting the existing behavior in situations where you have created per-environment plist files (e.g. `DEV-Info.plist` vs. `PROD-Info.plist`), and you just need to let CodePush know which prefix you want it to use in order to infer the correct app version of your update. This allows devs a bit more flexibility in how they organize their app's config, without requiring them to drop down to explicitly specifying the `--targetBinaryVersion` parameter when calling `release-react` (which feels like a failure on the command's part).

The `plistFile` parameter is for situations where your plist file is in an entirely arbitrary location and/or isn't using the standard `Info.plist` suffix (not common but possible). This has the benefit of providing maximum flexibility to the app dev, while still preventing them from having to explicitly specify the target binary version.

Therefore, the options for iOS are as follows:

1. If your app is a standard React Native app, then the `release-react` command will find your `Info.plist` correctly as it already does today. This is the simplest and most common solution.

2. If you've created per-environment plist files on top of the standard React Native app template, then you can optionally specify your environment-specific prefix when calling the `release-react` command via the new `--plisrtFilePrefix` parameter.

3. If your app has a "non-standard" layout (e.g. its a native iOS app with embedded RN views), then you can specify the exact path to your plist file via the new `--plistFile` parameter. This is the least common yet most flexible solution.

*NOTE: If you want to specify an explicit target binary version, then you can pass the `--targetBinaryVersion` parameter to the `release-react` command, which effectively "disables" the logic which tries to find a plist file and read the version from it.*

```shell
# Release an update using a plist file that is located in a
# "well-known" directory, and simply includes a custom prefix
code-push release-react foo ios --pre "DEV-"

# Release an update using a plist file in an arbitrary
# location and with an arbitrary file name
code-push release-react foo ios -p "../config/foo.plist"
```