### PR TITLE
Turn off implicit number conversion of non-hyphenated yargs arguments

### DIFF
--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -84,7 +84,8 @@ function accessKeyRemove(commandName: string, yargs: yargs.Argv): void {
 
 function addCommonConfiguration(yargs: yargs.Argv): void {
     yargs.wrap(/*columnLimit*/ null)
-        .strict()  // Validate hyphenated (named) arguments.
+        .string("_")                         // Interpret non-hyphenated arguments as strings (e.g. an app version of '1.10').
+        .strict()                            // Validate hyphenated (named) arguments.
         .fail((msg: string) => showHelp());  // Suppress the default error message.
 }
 
@@ -611,7 +612,7 @@ function createCommand(): cli.ICommand {
                 }
                 break;
 
-            
+
             case "debug":
                 cmd = <cli.IDebugCommand>{
                     type: cli.CommandType.debug,
@@ -769,8 +770,7 @@ function createCommand(): cli.ICommand {
 
                     releaseCommand.appName = arg1;
                     releaseCommand.package = arg2;
-                    // Floating points e.g. "1.2" gets parsed as a number by default, but semver requires strings.
-                    releaseCommand.appStoreVersion = arg3.toString();
+                    releaseCommand.appStoreVersion = arg3;
                     releaseCommand.deploymentName = argv["deploymentName"];
                     releaseCommand.description = argv["description"] ? backslash(argv["description"]) : "";
                     releaseCommand.disabled = argv["disabled"];
@@ -807,7 +807,7 @@ function createCommand(): cli.ICommand {
                     releaseReactCommand.appName = arg1;
                     releaseReactCommand.platform = arg2;
 
-                    releaseReactCommand.appStoreVersion = argv["targetBinaryVersion"];                    
+                    releaseReactCommand.appStoreVersion = argv["targetBinaryVersion"];
                     releaseReactCommand.bundleName = argv["bundleName"];
                     releaseReactCommand.deploymentName = argv["deploymentName"];
                     releaseReactCommand.disabled = argv["disabled"];
@@ -815,8 +815,8 @@ function createCommand(): cli.ICommand {
                     releaseReactCommand.development = argv["development"];
                     releaseReactCommand.entryFile = argv["entryFile"];
                     releaseReactCommand.mandatory = argv["mandatory"];
-                    releaseReactCommand.plistFile = argv["plistFile"];  
-                    releaseReactCommand.plistFilePrefix = argv["plistFilePrefix"];                    
+                    releaseReactCommand.plistFile = argv["plistFile"];
+                    releaseReactCommand.plistFilePrefix = argv["plistFilePrefix"];
                     releaseReactCommand.rollout = getRolloutValue(argv["rollout"]);
                     releaseReactCommand.sourcemapOutput = argv["sourcemapOutput"];
                 }


### PR DESCRIPTION
This is a fix for #286, where an app store version specified on the command line like `1.10` would be converted by yargs to a number, i.e. `1.1`. This only applies to non-hyphenated parameters, and not flagged options, where the type is explicitly specified.

As this is somewhat unexpected, I've turned this number conversion off for all non-hyphenated arguments. For our existing commands, I've checked that all non-hyphenated arguments are strings, so there should be no side effects.