### PR TITLE
Update gradle-to-js dependency and bump package.json version

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push-cli",
-  "version": "1.12.3-beta",
+  "version": "1.12.4-beta",
   "description": "Management CLI for the CodePush service",
   "main": "script/cli.js",
   "scripts": {
@@ -30,7 +30,7 @@
     "cli-table": "^0.3.1",
     "code-push": "1.10.0-beta",
     "email-validator": "^1.0.3",
-    "gradle-to-js": "0.1.0",
+    "gradle-to-js": "0.1.1",
     "moment": "^2.10.6",
     "opener": "^1.4.1",
     "parse-duration": "0.1.1",


### PR DESCRIPTION
This is to include [this change](https://github.com/ninetwozero/gradle-to-js/pull/3) that allows gradle files that include function definitions to be parsed correctly.