### PR TITLE
Add option to sign releases with a private key

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -175,10 +175,11 @@ export interface IReleaseBaseCommand extends ICommand, IPackageInfo {
     appName: string;
     appStoreVersion: string;
     deploymentName: string;
+    signingKeyPath?: string;
 }
 
 export interface IReleaseCommand extends IReleaseBaseCommand {
-    package: string;
+    path: string;
 }
 
 export interface IReleaseCordovaCommand extends IReleaseBaseCommand {
@@ -210,3 +211,5 @@ export interface ISessionListCommand extends ICommand {
 export interface ISessionRemoveCommand extends ICommand {
     machineName: string;
 }
+
+export type ReleaseHook = (currentCommand: IReleaseCommand, originalCommand: IReleaseCommand) => Q.Promise<IReleaseCommand|void>;

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,6 +31,7 @@
     "code-push": "1.10.0-beta",
     "email-validator": "^1.0.3",
     "gradle-to-js": "0.1.1",
+    "jsonwebtoken": "^7.0.0",
     "moment": "^2.10.6",
     "opener": "^1.4.1",
     "parse-duration": "0.1.1",

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -381,12 +381,13 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         yargs.usage(USAGE_PREFIX + " release <appName> <updateContentsPath> <targetBinaryVersion> [options]")
             .demand(/*count*/ 4, /*max*/ 4)  // Require exactly four non-option arguments.
             .example("release MyApp app.js \"*\"", "Releases the \"app.js\" file to the \"MyApp\" app's \"Staging\" deployment, targeting any binary version using the \"*\" wildcard range syntax.")
-            .example("release MyApp ./platforms/ios/www 1.0.3 -d Production", "Releases the \"./platforms/ios/www\" folder and all its contents to the \"MyApp\" app's \"Production\" deployment, targeting only the 1.0.3 binary version")
+            .example("release MyApp ./platforms/ios/www 1.0.3 -d Production -k ~/.ssh/codepush_rsa", "Releases the \"./platforms/ios/www\" folder and all its contents to the \"MyApp\" app's \"Production\" deployment, targeting the 1.0.3 binary version and signed with the \"codepush_rsa\" private key")
             .example("release MyApp ./platforms/ios/www 1.0.3 -d Production -r 20", "Releases the \"./platforms/ios/www\" folder and all its contents to the \"MyApp\" app's \"Production\" deployment, targeting the 1.0.3 binary version and rolling out to about 20% of the users")
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "Deployment to release the update to", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "Description of the changes made to the app in this release", type: "string" })
             .option("disabled", { alias: "x", default: false, demand: false, description: "Specifies whether this release should be immediately downloadable", type: "boolean" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Specifies whether this release should be considered mandatory", type: "boolean" })
+            .option("signingKey", { alias: "k", default: false, demand: false, description: "Specifies the location of a RSA private key to sign the release with", type: "string" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be available to", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
@@ -396,13 +397,14 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         yargs.usage(USAGE_PREFIX + " release-cordova <appName> <platform> [options]")
             .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
             .example("release-cordova MyApp ios", "Releases the Cordova iOS project in the current working directory to the \"MyApp\" app's \"Staging\" deployment")
-            .example("release-cordova MyApp android -d Production", "Releases the Cordova Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment")
+            .example("release-cordova MyApp android -d Production -k ~/.ssh/codepush_rsa", "Releases the Cordova Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment, signed with the \"codepush_rsa\" private key")
             .option("build", { alias: "b", default: false, demand: false, description: "Invoke \"cordova build\" instead of \"cordova prepare\"", type: "boolean" })
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "Deployment to release the update to", type: "string" })
             .option("description", { alias: "des", default: null, demand: false, description: "Description of the changes made to the app in this release", type: "string" })
             .option("disabled", { alias: "x", default: false, demand: false, description: "Specifies whether this release should be immediately downloadable", type: "boolean" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Specifies whether this release should be considered mandatory", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
+            .option("signingKey", { alias: "k", default: false, demand: false, description: "Specifies the location of a RSA private key to sign the release with", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the config.xml file.", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
@@ -412,7 +414,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         yargs.usage(USAGE_PREFIX + " release-react <appName> <platform> [options]")
             .demand(/*count*/ 3, /*max*/ 3)  // Require exactly three non-option arguments.
             .example("release-react MyApp ios", "Releases the React Native iOS project in the current working directory to the \"MyApp\" app's \"Staging\" deployment")
-            .example("release-react MyApp android -d Production", "Releases the React Native Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment")
+            .example("release-react MyApp android -d Production -k ~/.ssh/codepush_rsa", "Releases the React Native Android project in the current working directory to the \"MyApp\" app's \"Production\" deployment, signed with the \"codepush_rsa\" private key")
             .example("release-react MyApp windows --dev", "Releases the development bundle of the React Native Windows project in the current working directory to the \"MyApp\" app's \"Staging\" deployment")
             .option("bundleName", { alias: "b", default: null, demand: false, description: "Name of the generated JS bundle file. If unspecified, the standard bundle name will be used, depending on the specified platform: \"main.jsbundle\" (iOS), \"index.android.bundle\" (Android) or \"index.windows.bundle\" (Windows)", type: "string" })
             .option("deploymentName", { alias: "d", default: "Staging", demand: false, description: "Deployment to release the update to", type: "string" })
@@ -425,6 +427,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("plistFile", { alias: "p", default: null, demand: false, description: "Path to the plist file which specifies the binary version you want to target this release at (iOS only)." })
             .option("plistFilePrefix", { alias: "pre", default: null, demand: false, description: "Prefix to append to the file name when attempting to find your app's Info.plist file (iOS only)." })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
+            .option("signingKey", { alias: "k", default: false, demand: false, description: "Specifies the location of a RSA private key to sign the release with", type: "string" })
             .option("sourcemapOutput", { alias: "s", default: null, demand: false, description: "Path to where the sourcemap for the resulting bundle should be written. If omitted, a sourcemap will not be generated.", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the \"Info.plist\" (iOS), \"build.gradle\" (Android) or \"Package.appxmanifest\" (Windows) files.", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
@@ -770,13 +773,14 @@ function createCommand(): cli.ICommand {
                     var releaseCommand = <cli.IReleaseCommand>cmd;
 
                     releaseCommand.appName = arg1;
-                    releaseCommand.package = arg2;
+                    releaseCommand.path = arg2;
                     releaseCommand.appStoreVersion = arg3;
                     releaseCommand.deploymentName = argv["deploymentName"];
                     releaseCommand.description = argv["description"] ? backslash(argv["description"]) : "";
                     releaseCommand.disabled = argv["disabled"];
                     releaseCommand.mandatory = argv["mandatory"];
                     releaseCommand.rollout = getRolloutValue(argv["rollout"]);
+                    releaseCommand.signingKeyPath = argv["signingKey"];
                 }
                 break;
 
@@ -789,13 +793,14 @@ function createCommand(): cli.ICommand {
                     releaseCordovaCommand.appName = arg1;
                     releaseCordovaCommand.platform = arg2;
 
+                    releaseCordovaCommand.appStoreVersion = argv["targetBinaryVersion"];
                     releaseCordovaCommand.build = argv["build"];
                     releaseCordovaCommand.deploymentName = argv["deploymentName"];
                     releaseCordovaCommand.description = argv["description"] ? backslash(argv["description"]) : "";
                     releaseCordovaCommand.disabled = argv["disabled"];
                     releaseCordovaCommand.mandatory = argv["mandatory"];
                     releaseCordovaCommand.rollout = getRolloutValue(argv["rollout"]);
-                    releaseCordovaCommand.appStoreVersion = argv["targetBinaryVersion"];
+                    releaseCordovaCommand.signingKeyPath = argv["signingKey"];
                 }
                 break;
 
@@ -820,6 +825,7 @@ function createCommand(): cli.ICommand {
                     releaseReactCommand.plistFile = argv["plistFile"];
                     releaseReactCommand.plistFilePrefix = argv["plistFilePrefix"];
                     releaseReactCommand.rollout = getRolloutValue(argv["rollout"]);
+                    releaseReactCommand.signingKeyPath = argv["signingKey"];
                     releaseReactCommand.sourcemapOutput = argv["sourcemapOutput"];
                 }
                 break;

--- a/cli/script/hash-utils.ts
+++ b/cli/script/hash-utils.ts
@@ -1,6 +1,8 @@
 /**
  * NOTE!!! This utility file is duplicated for use by the CodePush service (for server-driven hashing/
- * integrity checks) and Management SDK (for end-to-end code signing), please keep them in sync.
+ * integrity checks) and CLI (for end-to-end code signing), please keep them in sync.
+ *
+ * Also, the same hashing behavior must be preserved in the native SDK's.
  */
 
 import * as crypto from "crypto";
@@ -109,7 +111,7 @@ export function generatePackageManifestFromDirectory(directoryPath: string, base
         }
 
         if (!files || files.length === 0) {
-            deferred.reject("Error: Can't sign the release because no files were found.");
+            deferred.reject("Can't hash the directory because no files were found.");
             return;
         }
 
@@ -225,16 +227,19 @@ export class PackageManifest {
     }
 
     public static normalizePath(filePath: string): string {
-        return filePath.replace("\\", "/");
+        return filePath.replace(/\\/g, "/");
     }
 
     public static isIgnored(relativeFilePath: string): boolean {
         const __MACOSX = "__MACOSX/";
         const DS_STORE = ".DS_Store";
+        const CODEPUSH_METADATA = ".codepushrelease";
 
         return startsWith(relativeFilePath, __MACOSX)
             || relativeFilePath === DS_STORE
-            || endsWith(relativeFilePath, "/" + DS_STORE);
+            || endsWith(relativeFilePath, "/" + DS_STORE)
+            || relativeFilePath === CODEPUSH_METADATA
+            || endsWith(relativeFilePath, "/" + CODEPUSH_METADATA);
     }
 }
 

--- a/cli/script/release-hooks/signing.ts
+++ b/cli/script/release-hooks/signing.ts
@@ -1,0 +1,87 @@
+import * as cli from "../../definitions/cli";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as hashUtils from "../hash-utils";
+import * as jwt from "jsonwebtoken";
+import * as os from "os";
+import * as path from "path";
+import * as q from "q";
+var rimraf = require("rimraf");
+
+var CURRENT_CLAIM_VERSION: string = "1.0.0";
+var METADATA_FILE_NAME: string = ".codepushrelease"
+
+interface CodeSigningClaims {
+    claimVersion: string;
+    contentHash: string;
+}
+
+export default function sign(command: cli.IReleaseCommand): q.Promise<cli.IReleaseCommand> {
+    if (!command.signingKeyPath) {
+        return q(command);
+    }
+
+    var signingKey: Buffer;
+    var signatureFilePath: string;
+
+    return q(<void>null)
+        .then(() => {
+            try {
+                signingKey = fs.readFileSync(command.signingKeyPath);
+            } catch (err) {
+                return q.reject(new Error(`The path specified for the signing key ("${command.signingKeyPath}") was not valid`));
+            }
+
+            if (!fs.lstatSync(command.path).isDirectory()) {
+                // If releasing a single file, copy the file to a temporary 'CodePush' directory in which to publish the release
+                var outputFolderPath: string = path.join(os.tmpdir(), "CodePush");
+                rimraf.sync(outputFolderPath);
+                fs.mkdirSync(outputFolderPath);
+
+                var outputFilePath: string = path.join(outputFolderPath, path.basename(command.path));
+                fs.writeFileSync(outputFilePath, fs.readFileSync(command.path));
+
+                command.path = outputFolderPath;
+            }
+
+            signatureFilePath = path.join(command.path, METADATA_FILE_NAME);
+            try {
+                fs.accessSync(signatureFilePath, fs.F_OK);
+                console.log(`Deleting previous release signature at ${signatureFilePath}`);
+                rimraf.sync(signatureFilePath);
+            } catch (err) {
+            }
+
+            return hashUtils.generatePackageHashFromDirectory(command.path, path.join(command.path, ".."));
+        })
+        .then((hash: string) => {
+            var claims: CodeSigningClaims = {
+                claimVersion: CURRENT_CLAIM_VERSION,
+                contentHash: hash
+            };
+
+            return q.nfcall<string>(jwt.sign, claims, signingKey, { algorithm: "RS256" })
+                .catch((err: Error) => {
+                    return q.reject<string>(new Error("The specified signing key file was not valid"));
+                });
+        })
+        .then((signedJwt: string) => {
+            var deferred = q.defer<void>();
+
+            fs.writeFile(signatureFilePath, signedJwt, (err: Error) => {
+                if (err) {
+                    deferred.reject(err);
+                } else {
+                    console.log(`Generated a release signature and wrote it to ${signatureFilePath}`);
+                    deferred.resolve(<void>null);
+                }
+            });
+
+            return deferred.promise;
+        })
+        .then(() => command)
+        .catch((err: Error) => {
+            err.message = `Could not sign package: ${err.message}`;
+            return q.reject<cli.IReleaseCommand>(err);
+        });
+}

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -1044,7 +1044,7 @@ describe("CLI", () => {
             mandatory: false,
             rollout: null,
             appStoreVersion: "not semver",
-            package: "./resources"
+            path: "./resources"
         };
 
         releaseHelperFunction(command, done, "Please use a semver-compliant target binary version range, for example \"1.0.0\", \"*\" or \"^1.2.3\".");
@@ -1059,7 +1059,7 @@ describe("CLI", () => {
             mandatory: false,
             rollout: null,
             appStoreVersion: "1.0.0",
-            package: "/fake/path/test/file.zip"
+            path: "/fake/path/test/file.zip"
         };
 
         releaseHelperFunction(command, done, INVALID_RELEASE_FILE_ERROR_MESSAGE);
@@ -1074,7 +1074,7 @@ describe("CLI", () => {
             mandatory: false,
             rollout: null,
             appStoreVersion: "1.0.0",
-            package: "/fake/path/test/file.ipa"
+            path: "/fake/path/test/file.ipa"
         };
 
         releaseHelperFunction(command, done, INVALID_RELEASE_FILE_ERROR_MESSAGE);
@@ -1089,7 +1089,7 @@ describe("CLI", () => {
             mandatory: false,
             rollout: null,
             appStoreVersion: "1.0.0",
-            package: "/fake/path/test/file.apk"
+            path: "/fake/path/test/file.apk"
         };
 
         releaseHelperFunction(command, done, INVALID_RELEASE_FILE_ERROR_MESSAGE);
@@ -1211,7 +1211,7 @@ describe("CLI", () => {
         var oldWd: string = process.cwd();
         ensureInTestAppDirectory();
 
-        var expectedReleaseCommand: any = {
+        var expectedReleaseCommand = <cli.IReleaseCommand>{
             type: cli.CommandType.release,
             appName: "a",
             appStoreVersion: "0.0.1",
@@ -1220,9 +1220,9 @@ describe("CLI", () => {
             description: "Test config.xml app version read",
             mandatory: false,
             rollout: null,
-            package: path.join(process.cwd(), "platforms", "ios", "www"),
+            path: path.join(process.cwd(), "platforms", "ios", "www"),
             platform: "ios"
-        }
+        };
 
         var execSync: Sinon.SinonStub = sandbox.stub(cmdexec, "execSync", (command: string, options: any) => { });
         var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release");
@@ -1258,7 +1258,7 @@ describe("CLI", () => {
         var oldWd: string = process.cwd();
         ensureInTestAppDirectory();
 
-        var expectedReleaseCommand: any = {
+        var expectedReleaseCommand = <cli.IReleaseCommand>{
             type: cli.CommandType.release,
             appName: "a",
             appStoreVersion: "0.0.1",
@@ -1267,9 +1267,9 @@ describe("CLI", () => {
             description: "Test android package resolution",
             mandatory: false,
             rollout: null,
-            package: path.join(process.cwd(), "platforms", "android", "assets", "www"),
+            path: path.join(process.cwd(), "platforms", "android", "assets", "www"),
             platform: "android"
-        }
+        };
 
         var execSync: Sinon.SinonStub = sandbox.stub(cmdexec, "execSync", (command: string, options: any) => { });
         var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release");
@@ -1436,7 +1436,7 @@ describe("CLI", () => {
         cmdexec.execute(command)
             .then(() => {
                 var releaseCommand: cli.IReleaseCommand = <any>command;
-                releaseCommand.package = path.join(os.tmpdir(), "CodePush");
+                releaseCommand.path = path.join(os.tmpdir(), "CodePush");
                 releaseCommand.appStoreVersion = "1.2.3";
 
                 sinon.assert.calledOnce(spawn);
@@ -1473,7 +1473,7 @@ describe("CLI", () => {
             .then(() => {
                 var releaseCommand: cli.IReleaseCommand = <any>clone(command);
                 var packagePath: string = path.join(os.tmpdir(), "CodePush");
-                releaseCommand.package = packagePath;
+                releaseCommand.path = packagePath;
                 releaseCommand.appStoreVersion = "1.2.3";
 
                 sinon.assert.calledOnce(spawn);
@@ -1510,7 +1510,7 @@ describe("CLI", () => {
             .then(() => {
                 var releaseCommand: cli.IReleaseCommand = <any>clone(command);
                 var packagePath: string = path.join(os.tmpdir(), "CodePush");
-                releaseCommand.package = packagePath;
+                releaseCommand.path = packagePath;
                 releaseCommand.appStoreVersion = "1.0.0";
 
                 sinon.assert.calledOnce(spawn);
@@ -1547,7 +1547,7 @@ describe("CLI", () => {
             .then(() => {
                 var releaseCommand: cli.IReleaseCommand = <any>clone(command);
                 var packagePath = path.join(os.tmpdir(), "CodePush");
-                releaseCommand.package = packagePath;
+                releaseCommand.path = packagePath;
                 releaseCommand.appStoreVersion = "1.0.0";
 
                 sinon.assert.calledOnce(spawn);
@@ -1587,7 +1587,7 @@ describe("CLI", () => {
         cmdexec.execute(command)
             .then(() => {
                 var releaseCommand: cli.IReleaseCommand = <any>command;
-                releaseCommand.package = path.join(os.tmpdir(), "CodePush");
+                releaseCommand.path = path.join(os.tmpdir(), "CodePush");
                 releaseCommand.appStoreVersion = "1.2.3";
 
                 sinon.assert.calledOnce(spawn);
@@ -1626,7 +1626,7 @@ describe("CLI", () => {
         cmdexec.execute(command)
             .then(() => {
                 var releaseCommand: cli.IReleaseCommand = <any>command;
-                releaseCommand.package = path.join(os.tmpdir(), "CodePush");
+                releaseCommand.path = path.join(os.tmpdir(), "CodePush");
                 releaseCommand.appStoreVersion = "1.2.3";
 
                 sinon.assert.calledOnce(spawn);
@@ -1665,7 +1665,7 @@ describe("CLI", () => {
         cmdexec.execute(command)
             .then(() => {
                 var releaseCommand: cli.IReleaseCommand = <any>command;
-                releaseCommand.package = path.join(os.tmpdir(), "CodePush");
+                releaseCommand.path = path.join(os.tmpdir(), "CodePush");
 
                 sinon.assert.calledOnce(spawn);
                 var spawnCommand: string = spawn.args[0][0];


### PR DESCRIPTION
To use this feature, devs will need to:
1. Run `ssh-keygen` to generate a private/public key pair
2. Configure the CodePush SDK in their app with the public key file (PR upcoming), and perform an app store release
3. Perform CLI releases with the `-k` argument pointing to their private key file

Still to do:
1. Test on Windows
2. Update `README.md`
3. Get OSS approval for new dependencies

Potential future enhancements:
1. Support password-protected private key files
2. Refining the release hook mechanism, e.g. allowing aspects of behavior to be overriden
3. Allow hashing to be turned on independently to signing
4. Leverage KeyStore files and/or OSX keychain, and/or existing Android/iOS signing credentials
5. Cache public key or fingerprint on server for verification that releases are signed correctly
6. Key expiry
7. Certificates
8. Signing additional information beyond just the hash of the release, for example the app/deployment it was released on, the targeted binary versions, etc.
