### PR TITLE
Keep temp folder around when using release-react command

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1322,7 +1322,6 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
             log(chalk.cyan("\nReleasing update contents to CodePush:\n"));
             return release(releaseCommand);
         })
-        .then(() => deleteFolder(outputFolder))
         .catch((err: Error) => {
             deleteFolder(outputFolder);
             throw err;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "code-push",
+  "version": "1.12.3-beta",
   "devDependencies": {
     "chmod": "^0.2.1",
     "del": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "code-push",
   "devDependencies": {
     "chmod": "^0.2.1",
     "del": "^1.2.0",


### PR DESCRIPTION
Hey guys, I need to have access to the main.jsbundle (to upload to Sentry.io) after uploading the latest release using the `release-react` command.  The temp directory is already cleared out in `createEmptyTempReleaseFolder`.

Also npm was complaining about the package name and version missing when installing from a git url.
