### PR TITLE
Better error messages

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -634,10 +634,16 @@ function logout(command: cli.ICommand): Promise<void> {
         .then((): Promise<void> => {
             if (!connectionInfo.preserveAccessKeyOnLogout) {
                 var machineName: string = os.hostname();
-                return sdk.removeSession(machineName);
+                return sdk.removeSession(machineName)
+                    .catch((error: CodePushError) => {
+                        // If we are not authenticated or the session doesn't exist anymore, just swallow the error instead of displaying it
+                        if (error.statusCode !== 401 && error.statusCode !== 404) {
+                            throw error;
+                        }
+                    });
             }
         })
-        .finally((): void => {
+        .then((): void => {
             sdk = null;
             deleteConnectionInfoCache();
         });

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1538,7 +1538,6 @@ function getSdk(accessKey: string, headers: Headers, customServerUrl: string, pr
                         .catch((error: any) => {
                             if (error.statusCode && error.statusCode === 401) {
                                 deleteConnectionInfoCache(/* printMessage */ false);
-                                error.message = `Invalid credentials. Run the 'code-push login' command to authenticate with the CodePush server.`;
                             }
 
                             throw error;

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -52,6 +52,12 @@ class AccountManager {
 
     private static API_VERSION: number = 2;
 
+    public static ERROR_GATEWAY_TIMEOUT = 504;  // Used if there is a network error
+    public static ERROR_INTERNAL_SERVER = 500;
+    public static ERROR_NOT_FOUND = 404;
+    public static ERROR_CONFLICT = 409;         // Used if the resource already exists
+    public static ERROR_UNAUTHORIZED = 401;
+
     private _accessKey: string;
     private _serverUrl: string;
     private _customHeaders: Headers;
@@ -78,7 +84,7 @@ class AccountManager {
 
             request.end((err: any, res: superagent.Response) => {
                 var status: number = this.getErrorStatus(err, res);
-                if (err && status !== 401) {
+                if (err && status !== AccountManager.ERROR_UNAUTHORIZED) {
                     reject(this.getCodePushError(err, res));
                     return;
                 }
@@ -393,7 +399,7 @@ class AccountManager {
 
                 if (res.ok) {
                     if (expectResponseBody && !body) {
-                        reject(<CodePushError>{ message: `Could not parse response: ${res.text}`, statusCode: 500 });
+                        reject(<CodePushError>{ message: `Could not parse response: ${res.text}`, statusCode: AccountManager.ERROR_INTERNAL_SERVER });
                     } else {
                         resolve(<JsonResponse>{
                             headers: res.header,
@@ -423,7 +429,7 @@ class AccountManager {
     }
 
     private getErrorStatus(error: any, response: superagent.Response): number {
-        return (error && error.status) || (response && response.status) || 504;     // Default to 504 Gateway Timeout for network errors
+        return (error && error.status) || (response && response.status) || AccountManager.ERROR_GATEWAY_TIMEOUT;
     }
 
     private getErrorMessage(error: Error, response: superagent.Response): string {

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -412,6 +412,10 @@ class AccountManager {
     }
 
     private getCodePushError(error: any, response: superagent.Response): CodePushError {
+        if (error.syscall === "getaddrinfo") {
+            error.message = `Unable to connect to the CodePush server. Are you offline, or behind a firewall or proxy?\n(${error.message})`;
+        }
+
         return {
             message: this.getErrorMessage(error, response),
             statusCode: this.getErrorStatus(error, response)
@@ -419,7 +423,7 @@ class AccountManager {
     }
 
     private getErrorStatus(error: any, response: superagent.Response): number {
-        return (error && error.status) || (response && response.status);
+        return (error && error.status) || (response && response.status) || 504;     // Default to 504 Gateway Timeout for network errors
     }
 
     private getErrorMessage(error: Error, response: superagent.Response): string {


### PR DESCRIPTION
1. Fix the error message when there is a network issue (https://github.com/Microsoft/react-native-code-push/issues/124)
1. Improve error messages when you log out, and when server authentication fails. This should further mitigate a lot of the confusion around expired access keys previously reported on slack and elsewhere.
1. Add error codes to the SDK, so that consumers can better handle errors