### PR TITLE
Fix failure to unlink temporary file

### DIFF
--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -318,8 +318,8 @@ class AccountManager {
                     })
                     .end((err: any, res: superagent.Response) => {
                         
-                        if (file.isTemporary) {
-                            fs.unlinkSync(filePath);
+                        if (packageFile.isTemporary) {
+                            fs.unlinkSync(packageFile.path);
                         }
                         
                         if (err) {


### PR DESCRIPTION
- Need to remove the `packageFile` and not the File object, otherwise the temporary `.zip` file sticks around after a `release` command.
- @silhouettes 