### PR TITLE
package: update `gradle-to-js` package version to `0.2.5`

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,7 @@
     "cli-table": "^0.3.1",
     "code-push": "1.11.1-beta",
     "email-validator": "^1.0.3",
-    "gradle-to-js": "0.1.1",
+    "gradle-to-js": "0.2.5",
     "moment": "^2.10.6",
     "opener": "^1.4.1",
     "parse-duration": "0.1.1",


### PR DESCRIPTION
`0.2.5` package version contains fix of following issue:
> parsing issue occurs in case `build.gradle` file contains several `android` closures
> https://github.com/ninetwozero/gradle-to-js/issues/4

Fix https://github.com/Microsoft/code-push/issues/349