### PR TITLE
code-push-cli: implement “outputDir” parameter

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -429,6 +429,7 @@ code-push release-react <appName> <platform>
 [--sourcemapOutput <sourcemapOutput>]
 [--targetBinaryVersion <targetBinaryVersion>]
 [--rollout <rolloutPercentage>]
+[--outputDir <outputDir>]
 ```
 
 The `release-react` command is a React Native-specific version of the "vanilla" [`release`](#releasing-app-updates) command, which supports all of the same parameters (e.g. `--mandatory`, `--description`), yet simplifies the process of releasing updates by performing the following additional behavior:
@@ -553,6 +554,12 @@ code-push release-react MyApp-iOS ios --pre "DEV-"
 This specifies the relative path to where the generated JS bundle's sourcemap file should be written. If left unspecified, sourcemaps will not be generated.
 
 *NOTE: This parameter can be set using either --sourcemapOutput or -s*
+
+#### Output directory parameter
+
+This specifies the relative path to where the assets, JS bundle and sourcemap files should be written. If left unspecified, the assets, JS bundle and sourcemap will be copied to the `/tmp/CodePush` folder.
+
+*NOTE: This parameter can be set using either --outputDir or -o*
 
 ### Releasing Updates (Cordova)
 

--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -197,6 +197,7 @@ export interface IReleaseReactCommand extends IReleaseBaseCommand {
     plistFile?: string;
     plistFilePrefix?: string;
     sourcemapOutput?: string;
+    outputDir?: string;
 }
 
 export interface IRollbackCommand extends ICommand {

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1199,7 +1199,7 @@ export var releaseCordova = (command: cli.IReleaseCordovaCommand): Promise<void>
 export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => {
     var bundleName: string = command.bundleName;
     var entryFile: string = command.entryFile;
-    var outputFolder: string = path.join(os.tmpdir(), "CodePush");
+    var outputFolder: string = command.outputDir || path.join(os.tmpdir(), "CodePush");
     var platform: string = command.platform = command.platform.toLowerCase();
     var releaseCommand: cli.IReleaseCommand = <any>command;
     releaseCommand.package = outputFolder;
@@ -1256,6 +1256,10 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
         ? Q(command.appStoreVersion)
         : getReactNativeProjectAppVersion(command, projectName);
 
+    if (command.outputDir) {
+        command.sourcemapOutput = path.join(command.outputDir, bundleName + ".map");
+    }
+
     return appVersionPromise
         .then((appVersion: string) => {
             releaseCommand.appStoreVersion = appVersion;
@@ -1269,7 +1273,11 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
             log(chalk.cyan("\nReleasing update contents to CodePush:\n"));
             return release(releaseCommand);
         })
-        .then(() => deleteFolder(outputFolder))
+        .then(() => {
+            if (!command.outputDir) {
+                deleteFolder(outputFolder);
+            }
+        })
         .catch((err: Error) => {
             deleteFolder(outputFolder);
             throw err;

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -431,6 +431,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("sourcemapOutput", { alias: "s", default: null, demand: false, description: "Path to where the sourcemap for the resulting bundle should be written. If omitted, a sourcemap will not be generated.", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the \"Info.plist\" (iOS), \"build.gradle\" (Android) or \"Package.appxmanifest\" (Windows) files.", type: "string" })
+            .option("outputDir", { alias: "o", default: null, demand: false, description: "Path to where the bundle and sourcemap should be written. If omitted, a bundle and sourcemap will not be written.", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
         addCommonConfiguration(yargs);
@@ -829,6 +830,7 @@ function createCommand(): cli.ICommand {
                     releaseReactCommand.plistFilePrefix = argv["plistFilePrefix"];
                     releaseReactCommand.rollout = getRolloutValue(argv["rollout"]);
                     releaseReactCommand.sourcemapOutput = argv["sourcemapOutput"];
+                    releaseReactCommand.outputDir = argv["outputDir"];
                 }
                 break;
 


### PR DESCRIPTION
“outputDir” parameter is used to specify the path where bundle and sourcemap should be written.

Relate #376