### PR TITLE
Allow setting of node binary arguments via NODE_ARGS env var

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1347,14 +1347,21 @@ function requestAccessKey(): Promise<string> {
 }
 
 export var runReactNativeBundleCommand = (bundleName: string, development: boolean, entryFile: string, outputFolder: string, platform: string, sourcemapOutput: string): Promise<void> => {
-    var reactNativeBundleArgs = [
-        path.join("node_modules", "react-native", "local-cli", "cli.js"), "bundle",
-        "--assets-dest", outputFolder,
-        "--bundle-output", path.join(outputFolder, bundleName),
-        "--dev", development,
-        "--entry-file", entryFile,
-        "--platform", platform,
-    ];
+    let reactNativeBundleArgs: string[] = [];
+    let envNodeArgs: string = process.env.NODE_ARGS;
+
+    if (typeof envNodeArgs !== "undefined") {
+      Array.prototype.push.apply(reactNativeBundleArgs, envNodeArgs.trim().split(/\s+/));
+    }
+
+    Array.prototype.push.apply(reactNativeBundleArgs, [
+      path.join("node_modules", "react-native", "local-cli", "cli.js"), "bundle",
+      "--assets-dest", outputFolder,
+      "--bundle-output", path.join(outputFolder, bundleName),
+      "--dev", development,
+      "--entry-file", entryFile,
+      "--platform", platform,
+    ]);
 
     if (sourcemapOutput) {
         reactNativeBundleArgs.push("--sourcemap-output", sourcemapOutput);

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1348,7 +1348,7 @@ function requestAccessKey(): Promise<string> {
 
 export var runReactNativeBundleCommand = (bundleName: string, development: boolean, entryFile: string, outputFolder: string, platform: string, sourcemapOutput: string): Promise<void> => {
     let reactNativeBundleArgs: string[] = [];
-    let envNodeArgs: string = process.env.NODE_ARGS;
+    let envNodeArgs: string = process.env.CODE_PUSH_NODE_ARGS;
 
     if (typeof envNodeArgs !== "undefined") {
       Array.prototype.push.apply(reactNativeBundleArgs, envNodeArgs.trim().split(/\s+/));

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -1681,7 +1681,7 @@ describe("CLI", () => {
             .done();
     });
 
-    it("release-react applies arguments to node binary provided via the NODE_ARGS env var", (done: MochaDone): void => {
+    it("release-react applies arguments to node binary provided via the CODE_PUSH_NODE_ARGS env var", (done: MochaDone): void => {
         var bundleName = "bundle.js";
         var command: cli.IReleaseReactCommand = {
             type: cli.CommandType.releaseReact,
@@ -1699,8 +1699,8 @@ describe("CLI", () => {
 
         var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release", () => { return Q(<void>null) });
 
-        var _NODE_ARGS: string = process.env.NODE_ARGS;
-        process.env.NODE_ARGS = "  --foo=bar    --baz  ";
+        var _CODE_PUSH_NODE_ARGS: string = process.env.CODE_PUSH_NODE_ARGS;
+        process.env.CODE_PUSH_NODE_ARGS = "  --foo=bar    --baz  ";
 
         cmdexec.execute(command)
             .then(() => {
@@ -1718,7 +1718,7 @@ describe("CLI", () => {
                 );
                 assertJsonDescribesObject(JSON.stringify(release.args[0][0], /*replacer=*/ null, /*spacing=*/ 2), releaseCommand);
 
-                process.env.NODE_ARGS = _NODE_ARGS;
+                process.env.CODE_PUSH_NODE_ARGS = _CODE_PUSH_NODE_ARGS;
 
                 done();
             })

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -1681,6 +1681,50 @@ describe("CLI", () => {
             .done();
     });
 
+    it("release-react applies arguments to node binary provided via the NODE_ARGS env var", (done: MochaDone): void => {
+        var bundleName = "bundle.js";
+        var command: cli.IReleaseReactCommand = {
+            type: cli.CommandType.releaseReact,
+            appName: "a",
+            appStoreVersion: null,
+            bundleName: bundleName,
+            deploymentName: "Staging",
+            description: "Test default entry file",
+            mandatory: false,
+            rollout: null,
+            platform: "ios"
+        };
+
+        ensureInTestAppDirectory();
+
+        var release: Sinon.SinonSpy = sandbox.stub(cmdexec, "release", () => { return Q(<void>null) });
+
+        var _NODE_ARGS: string = process.env.NODE_ARGS;
+        process.env.NODE_ARGS = "  --foo=bar    --baz  ";
+
+        cmdexec.execute(command)
+            .then(() => {
+                var releaseCommand: cli.IReleaseCommand = <any>command;
+                releaseCommand.package = path.join(os.tmpdir(), "CodePush");
+                releaseCommand.appStoreVersion = "1.2.3";
+
+                sinon.assert.calledOnce(spawn);
+                var spawnCommand: string = spawn.args[0][0];
+                var spawnCommandArgs: string = spawn.args[0][1].join(" ");
+                assert.equal(spawnCommand, "node");
+                assert.equal(
+                    spawnCommandArgs,
+                    `--foo=bar --baz ${path.join("node_modules", "react-native", "local-cli", "cli.js")} bundle --assets-dest ${path.join(os.tmpdir(), "CodePush")} --bundle-output ${path.join(os.tmpdir(), "CodePush", bundleName)} --dev false --entry-file index.ios.js --platform ios`
+                );
+                assertJsonDescribesObject(JSON.stringify(release.args[0][0], /*replacer=*/ null, /*spacing=*/ 2), releaseCommand);
+
+                process.env.NODE_ARGS = _NODE_ARGS;
+
+                done();
+            })
+            .done();
+    });
+
     it("sessionList lists session name and expires fields", (done: MochaDone): void => {
         var command: cli.IAccessKeyListCommand = {
             type: cli.CommandType.sessionList,


### PR DESCRIPTION
Example usage:

```sh
env NODE_ARGS="--max-old-space-size=4096" code-push release-react APP_NAME ios
```

I couldn't find anywhere else secondary node processes are being spawned, but happy to add this functionality to those places as well.

Ref #215 