### PR TITLE
command-executor: check for app and deployment exist before releasing an update

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1207,9 +1207,6 @@ export var releaseCordova = (command: cli.IReleaseCordovaCommand): Promise<void>
                     throw new Error(`Unable to parse "config.xml" in the CWD. Ensure that the contents of "config.xml" is valid XML.`);
                 });
         })
-        .catch((err: Error) => {
-            throw err;
-        })
         .then((parsedConfig: any) => {
             var config: any = parsedConfig.widget;
 

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1149,58 +1149,66 @@ export var release = (command: cli.IReleaseCommand): Promise<void> => {
 }
 
 export var releaseCordova = (command: cli.IReleaseCordovaCommand): Promise<void> => {
-    var platform: string = command.platform.toLowerCase();
-    var projectRoot: string = process.cwd();
-    var platformFolder: string = path.join(projectRoot, "platforms", platform);
-    var platformCordova: string = path.join(platformFolder, "cordova");
-    var outputFolder: string;
-
-    if (platform === "ios") {
-        outputFolder = path.join(platformFolder, "www");
-    } else if (platform === "android") {
-        outputFolder = path.join(platformFolder, "assets", "www");
-    } else {
-        throw new Error("Platform must be either \"ios\" or \"android\".");
-    }
-
-    var cordovaCommand: string = command.build ? "build" : "prepare";
-    var cordovaCLI: string = "cordova";
-
-    // Check whether the Cordova or PhoneGap CLIs are
-    // installed, and if not, fail early
-    try {
-        which.sync(cordovaCLI);
-    } catch (e) {
-        try {
-            cordovaCLI = "phonegap";
-            which.sync(cordovaCLI);
-        } catch (e) {
-            throw new Error(`Unable to ${cordovaCommand} project. Please ensure that either the Cordova or PhoneGap CLI is installed.`);
-        }
-    }
-
-    log(chalk.cyan(`Running "${cordovaCLI} ${cordovaCommand}" command:\n`));
-    try {
-        execSync([cordovaCLI, cordovaCommand, platform, "--verbose"].join(" "), { stdio: "inherit" });
-    } catch (error) {
-        throw new Error(`Unable to ${cordovaCommand} project. Please ensure that the CWD represents a Cordova project and that the "${platform}" platform was added by running "${cordovaCLI} platform add ${platform}".`);
-    }
-
-    try {
-        var configString: string = fs.readFileSync(path.join(projectRoot, "config.xml"), { encoding: "utf8" });
-    } catch (error) {
-        throw new Error(`Unable to find or read "config.xml" in the CWD. The "release-cordova" command must be executed in a Cordova project folder.`);
-    }
-
-    var configPromise: Promise<any> = parseXml(configString);
     var releaseCommand: cli.IReleaseCommand = <any>command;
+    // Check for app and deployment exist before releasing an update.
+    // This validation helps to save about 1 minute or more in case user has typed wrong app or deployment name.
+    return sdk.getDeployment(command.appName, command.deploymentName)
+        .then((): any => {
+            var platform: string = command.platform.toLowerCase();
+            var projectRoot: string = process.cwd();
+            var platformFolder: string = path.join(projectRoot, "platforms", platform);
+            var platformCordova: string = path.join(platformFolder, "cordova");
+            var outputFolder: string;
 
-    releaseCommand.package = outputFolder;
-    releaseCommand.type = cli.CommandType.release;
+            if (platform === "ios") {
+                outputFolder = path.join(platformFolder, "www");
+            } else if (platform === "android") {
+                outputFolder = path.join(platformFolder, "assets", "www");
+            } else {
+                throw new Error("Platform must be either \"ios\" or \"android\".");
+            }
 
-    return configPromise
-        .catch((err: any) => {
-            throw new Error(`Unable to parse "config.xml" in the CWD. Ensure that the contents of "config.xml" is valid XML.`);
+            var cordovaCommand: string = command.build ? "build" : "prepare";
+            var cordovaCLI: string = "cordova";
+
+            // Check whether the Cordova or PhoneGap CLIs are
+            // installed, and if not, fail early
+            try {
+                which.sync(cordovaCLI);
+            } catch (e) {
+                try {
+                    cordovaCLI = "phonegap";
+                    which.sync(cordovaCLI);
+                } catch (e) {
+                    throw new Error(`Unable to ${cordovaCommand} project. Please ensure that either the Cordova or PhoneGap CLI is installed.`);
+                }
+            }
+
+            log(chalk.cyan(`Running "${cordovaCLI} ${cordovaCommand}" command:\n`));
+            try {
+                execSync([cordovaCLI, cordovaCommand, platform, "--verbose"].join(" "), { stdio: "inherit" });
+            } catch (error) {
+                throw new Error(`Unable to ${cordovaCommand} project. Please ensure that the CWD represents a Cordova project and that the "${platform}" platform was added by running "${cordovaCLI} platform add ${platform}".`);
+            }
+
+            try {
+                var configString: string = fs.readFileSync(path.join(projectRoot, "config.xml"), { encoding: "utf8" });
+            } catch (error) {
+                throw new Error(`Unable to find or read "config.xml" in the CWD. The "release-cordova" command must be executed in a Cordova project folder.`);
+            }
+
+            var configPromise: Promise<any> = parseXml(configString);
+
+            releaseCommand.package = outputFolder;
+            releaseCommand.type = cli.CommandType.release;
+
+            return configPromise
+                .catch((err: any) => {
+                    throw new Error(`Unable to parse "config.xml" in the CWD. Ensure that the contents of "config.xml" is valid XML.`);
+                });
+        })
+        .catch((err: Error) => {
+            throw err;
         })
         .then((parsedConfig: any) => {
             var config: any = parsedConfig.widget;
@@ -1226,65 +1234,70 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
     var outputFolder: string = command.outputDir || path.join(os.tmpdir(), "CodePush");
     var platform: string = command.platform = command.platform.toLowerCase();
     var releaseCommand: cli.IReleaseCommand = <any>command;
-    releaseCommand.package = outputFolder;
+    // Check for app and deployment exist before releasing an update.
+    // This validation helps to save about 1 minute or more in case user has typed wrong app or deployment name.
+    return sdk.getDeployment(command.appName, command.deploymentName)
+        .then((): any => {
+            releaseCommand.package = outputFolder;
 
-    switch (platform) {
-        case "android":
-        case "ios":
-        case "windows":
-            if (!bundleName) {
-                bundleName = platform === "ios"
-                    ? "main.jsbundle"
-                    : `index.${platform}.bundle`;
+            switch (platform) {
+                case "android":
+                case "ios":
+                case "windows":
+                    if (!bundleName) {
+                        bundleName = platform === "ios"
+                            ? "main.jsbundle"
+                            : `index.${platform}.bundle`;
+                    }
+
+                    break;
+                default:
+                    throw new Error("Platform must be either \"android\", \"ios\" or \"windows\".");
             }
 
-            break;
-        default:
-            throw new Error("Platform must be either \"android\", \"ios\" or \"windows\".");
-    }
+            try {
+                var projectPackageJson: any = require(path.join(process.cwd(), "package.json"));
+                var projectName: string = projectPackageJson.name;
+                if (!projectName) {
+                    throw new Error("The \"package.json\" file in the CWD does not have the \"name\" field set.");
+                }
 
-    try {
-        var projectPackageJson: any = require(path.join(process.cwd(), "package.json"));
-        var projectName: string = projectPackageJson.name;
-        if (!projectName) {
-            throw new Error("The \"package.json\" file in the CWD does not have the \"name\" field set.");
-        }
+                if (!projectPackageJson.dependencies["react-native"]) {
+                    throw new Error("The project in the CWD is not a React Native project.");
+                }
+            } catch (error) {
+                throw new Error("Unable to find or read \"package.json\" in the CWD. The \"release-react\" command must be executed in a React Native project folder.");
+            }
 
-        if (!projectPackageJson.dependencies["react-native"]) {
-            throw new Error("The project in the CWD is not a React Native project.");
-        }
-    } catch (error) {
-        throw new Error("Unable to find or read \"package.json\" in the CWD. The \"release-react\" command must be executed in a React Native project folder.");
-    }
+            if (!entryFile) {
+                entryFile = `index.${platform}.js`;
+                if (fileDoesNotExistOrIsDirectory(entryFile)) {
+                    entryFile = "index.js";
+                }
 
-    if (!entryFile) {
-        entryFile = `index.${platform}.js`;
-        if (fileDoesNotExistOrIsDirectory(entryFile)) {
-            entryFile = "index.js";
-        }
+                if (fileDoesNotExistOrIsDirectory(entryFile)) {
+                    throw new Error(`Entry file "index.${platform}.js" or "index.js" does not exist.`);
+                }
+            } else {
+                if (fileDoesNotExistOrIsDirectory(entryFile)) {
+                    throw new Error(`Entry file "${entryFile}" does not exist.`);
+                }
+            }
 
-        if (fileDoesNotExistOrIsDirectory(entryFile)) {
-            throw new Error(`Entry file "index.${platform}.js" or "index.js" does not exist.`);
-        }
-    } else {
-        if (fileDoesNotExistOrIsDirectory(entryFile)) {
-            throw new Error(`Entry file "${entryFile}" does not exist.`);
-        }
-    }
+            if (command.appStoreVersion) {
+                throwForInvalidSemverRange(command.appStoreVersion);
+            }
 
-    if (command.appStoreVersion) {
-        throwForInvalidSemverRange(command.appStoreVersion);
-    }
+            var appVersionPromise: Promise<string> = command.appStoreVersion
+                ? Q(command.appStoreVersion)
+                : getReactNativeProjectAppVersion(command, projectName);
 
-    var appVersionPromise: Promise<string> = command.appStoreVersion
-        ? Q(command.appStoreVersion)
-        : getReactNativeProjectAppVersion(command, projectName);
+            if (command.outputDir) {
+                command.sourcemapOutput = path.join(command.outputDir, bundleName + ".map");
+            }
 
-    if (command.outputDir) {
-        command.sourcemapOutput = path.join(command.outputDir, bundleName + ".map");
-    }
-
-    return appVersionPromise
+            return appVersionPromise;
+        })
         .then((appVersion: string) => {
             releaseCommand.appStoreVersion = appVersion;
             return createEmptyTempReleaseFolder(outputFolder);

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -1147,7 +1147,6 @@ describe("CLI", () => {
             .catch((err) => {
                 assert.equal(err.message, `Unable to ${cordovaCommand} project. Please ensure that the CWD represents a Cordova project and that the "${command.platform}" platform was added by running "cordova platform add ${command.platform}".`);
                 sinon.assert.notCalled(release);
-                sinon.assert.threw(releaseCordova, "Error");
                 done();
             })
             .done();
@@ -1177,7 +1176,6 @@ describe("CLI", () => {
             .catch((err) => {
                 assert.equal(err.message, `Unable to find or read "config.xml" in the CWD. The "release-cordova" command must be executed in a Cordova project folder.`);
                 sinon.assert.notCalled(release);
-                sinon.assert.threw(releaseCordova, "Error");
                 sinon.assert.calledOnce(execSync);
                 done();
             })
@@ -1207,7 +1205,6 @@ describe("CLI", () => {
             .catch((err) => {
                 assert.equal(err.message, "Platform must be either \"ios\" or \"android\".");
                 sinon.assert.notCalled(release);
-                sinon.assert.threw(releaseCordova, "Error");
                 sinon.assert.notCalled(spawn);
                 done();
             })
@@ -1330,7 +1327,6 @@ describe("CLI", () => {
             .catch((err) => {
                 assert.equal(err.message, "Unable to find or read \"package.json\" in the CWD. The \"release-react\" command must be executed in a React Native project folder.");
                 sinon.assert.notCalled(release);
-                sinon.assert.threw(releaseReact, "Error");
                 sinon.assert.notCalled(spawn);
                 done();
             })
@@ -1362,7 +1358,6 @@ describe("CLI", () => {
             .catch((err) => {
                 assert.equal(err.message, "Entry file \"doesntexist.js\" does not exist.");
                 sinon.assert.notCalled(release);
-                sinon.assert.threw(releaseReact, "Error");
                 sinon.assert.notCalled(spawn);
                 done();
             })
@@ -1393,7 +1388,6 @@ describe("CLI", () => {
             .catch((err) => {
                 assert.equal(err.message, "Platform must be either \"android\", \"ios\" or \"windows\".");
                 sinon.assert.notCalled(release);
-                sinon.assert.threw(releaseReact, "Error");
                 sinon.assert.notCalled(spawn);
                 done();
             })
@@ -1427,7 +1421,6 @@ describe("CLI", () => {
             .catch((err) => {
                 assert.equal(err.message, "Please use a semver-compliant target binary version range, for example \"1.0.0\", \"*\" or \"^1.2.3\".");
                 sinon.assert.notCalled(release);
-                sinon.assert.threw(releaseReact, "Error");
                 sinon.assert.notCalled(spawn);
                 done();
             })

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -32,6 +32,25 @@ const DEFAULT_ACCESS_KEY_MAX_AGE = 1000 * 60 * 60 * 24 * 60; // 60 days
 const TEST_MACHINE_NAME = "Test machine";
 
 export class SdkStub {
+    private productionDeployment: codePush.Deployment = {
+        name: "Production",
+        key: "6"
+    };
+    private stagingDeployment: codePush.Deployment = {
+        name: "Staging",
+        key: "6",
+        package: {
+            appVersion: "1.0.0",
+            description: "fgh",
+            label: "v2",
+            packageHash: "jkl",
+            isMandatory: true,
+            size: 10,
+            blobUrl: "http://mno.pqr",
+            uploadTime: 1000
+        }
+    };
+
     public getAccountInfo(): Promise<codePush.Account> {
         return Q(<codePush.Account>{
             email: "a@a.com"
@@ -65,14 +84,14 @@ export class SdkStub {
         return Q(<void>null);
     }
 
-    public addDeployment(appId: string, name: string): Promise<codePush.Deployment> {
+    public addDeployment(appName: string, deploymentName: string): Promise<codePush.Deployment> {
         return Q(<codePush.Deployment>{
-            name: name,
+            name: deploymentName,
             key: "6"
         });
     }
 
-    public clearDeploymentHistory(appId: string, deployment: string): Promise<void> {
+    public clearDeploymentHistory(appName: string, deploymentName: string): Promise<void> {
         return Q(<void>null);
     }
 
@@ -103,27 +122,27 @@ export class SdkStub {
         }]);
     }
 
-    public getDeployments(appId: string): Promise<codePush.Deployment[]> {
-        return Q([<codePush.Deployment>{
-            name: "Production",
-            key: "6"
-        }, <codePush.Deployment>{
-            name: "Staging",
-            key: "6",
-            package: {
-                appVersion: "1.0.0",
-                description: "fgh",
-                label: "v2",
-                packageHash: "jkl",
-                isMandatory: true,
-                size: 10,
-                blobUrl: "http://mno.pqr",
-                uploadTime: 1000
-            }
-        }]);
+    public getDeployments(appName: string): Promise<codePush.Deployment[]> {
+        if (appName === "a") {
+            return Q([this.productionDeployment, this.stagingDeployment]);
+        }
+    
+        return Q.reject<codePush.Deployment[]>();
     }
 
-    public getDeploymentHistory(appId: string, deploymentId: string): Promise<codePush.Package[]> {
+    public getDeployment(appName: string, deploymentName: string): Promise<codePush.Deployment> {
+        if (appName === "a") {
+            if (deploymentName === "Production") {
+                return Q(this.productionDeployment);
+            } else if (deploymentName === "Staging") {
+                return Q(this.stagingDeployment);
+            }
+        }
+
+        return Q.reject<codePush.Deployment>();
+    }
+
+    public getDeploymentHistory(appName: string, deploymentName: string): Promise<codePush.Package[]> {
         return Q([
             <codePush.Package>{
                 description: null,
@@ -148,7 +167,7 @@ export class SdkStub {
         ]);
     }
 
-    public getDeploymentMetrics(appId: string, deploymentId: string): Promise<any> {
+    public getDeploymentMetrics(appName: string, deploymentName: string): Promise<any> {
         return Q({
             "1.0.0": {
                 active: 123
@@ -189,7 +208,7 @@ export class SdkStub {
         return Q(<void>null);
     }
 
-    public release(appId: string, deploymentId: string): Promise<string> {
+    public release(appName: string, deploymentName: string): Promise<string> {
         return Q("Successfully released");
     }
 
@@ -197,7 +216,7 @@ export class SdkStub {
         return Q(<void>null);
     }
 
-    public removeApp(appId: string): Promise<void> {
+    public removeApp(appName: string): Promise<void> {
         return Q(<void>null);
     }
 
@@ -205,7 +224,7 @@ export class SdkStub {
         return Q(<void>null);
     }
 
-    public removeDeployment(appId: string, deployment: string): Promise<void> {
+    public removeDeployment(appName: string, deploymentName: string): Promise<void> {
         return Q(<void>null);
     }
 
@@ -225,7 +244,7 @@ export class SdkStub {
         return Q(<void>null);
     }
 
-    public renameDeployment(appId: string, deployment: codePush.Deployment): Promise<void> {
+    public renameDeployment(appName: string, deploymentName: codePush.Deployment): Promise<void> {
         return Q(<void>null);
     }
 }


### PR DESCRIPTION
This validation helps to save about 1 minute or more in case user has typed wrong app name.
In case app (or deployment) does not exist the error will be shown with the following outputs: 
`App "myapp" does not exist` or `Deployment "mydeployment" does not exist`.
So user have not to wait until code-push update is ready for upload.

Relate https://github.com/Microsoft/react-native-code-push/issues/706