### PR TITLE
Small tweak to fix unit tests

### DIFF
--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -94,8 +94,8 @@ export var confirm = (message: string = "Are you sure?"): Promise<boolean> => {
                 resolve(true);
             } else {
                 if (!rejected){
-                    console.log("Invalid response: \"" + result.response + "\"");               
-                } 
+                    console.log("Invalid response: \"" + result.response + "\"");
+                }
                 resolve(false);
             }
         });
@@ -967,7 +967,7 @@ function getReactNativeProjectAppVersion(command: cli.IReleaseReactCommand, proj
                             appVersion = parsedProperties[propertyName];
                             if (appVersion) {
                                 break;
-                            } 
+                            }
                         } catch (e) {
                             throw new Error(`Unable to parse "${propertiesFile}". Please ensure it is a well-formed properties file.`);
                         }
@@ -1085,7 +1085,7 @@ function promote(command: cli.IPromoteCommand): Promise<void> {
 
     return sdk.promote(command.appName, command.sourceDeploymentName, command.destDeploymentName, packageInfo)
         .then((): void => {
-            log("Successfully promoted " + (command.label !== null ? "\"" + command.label + "\" of " : "") + "the \"" + command.sourceDeploymentName + "\" deployment of the \"" + command.appName + "\" app to the \"" + command.destDeploymentName + "\" deployment.");
+            log("Successfully promoted " + (command.label ? "\"" + command.label + "\" of " : "") + "the \"" + command.sourceDeploymentName + "\" deployment of the \"" + command.appName + "\" app to the \"" + command.destDeploymentName + "\" deployment.");
         })
         .catch((err: CodePushError) => releaseErrorHandler(err, command));
 }
@@ -1112,15 +1112,15 @@ function patch(command: cli.IPatchCommand): Promise<void> {
 }
 
 export var release = (command: cli.IReleaseCommand): Promise<void> => {
-    
+
     if (isBinaryOrZip(command.package)) {
         throw new Error("It is unnecessary to package releases in a .zip or binary file. Please specify the direct path to the update content's directory (e.g. /platforms/ios/www) or file (e.g. main.jsbundle).");
     }
-    
+
     throwForInvalidSemverRange(command.appStoreVersion);
     var filePath: string = command.package;
     var isSingleFilePackage: boolean = true;
-    
+
     if (fs.lstatSync(filePath).isDirectory()) {
         isSingleFilePackage = false;
     }
@@ -1144,7 +1144,7 @@ export var release = (command: cli.IReleaseCommand): Promise<void> => {
         isMandatory: command.mandatory,
         rollout: command.rollout
     };
-    
+
     return sdk.isAuthenticated(true)
         .then((isAuth: boolean): Promise<void> => {
             return sdk.release(command.appName, command.deploymentName, filePath, command.appStoreVersion, updateMetadata, uploadProgress);
@@ -1175,7 +1175,7 @@ export var releaseCordova = (command: cli.IReleaseCordovaCommand): Promise<void>
                 throw new Error("Platform must be either \"ios\" or \"android\".");
             }
 
-            var cordovaCommand: string = command.build ? 
+            var cordovaCommand: string = command.build ?
                 (command.isReleaseBuildType ? "build --release" : "build") :
                 "prepare";
             var cordovaCLI: string = "cordova";


### PR DESCRIPTION
(Add ?w=1 to the end of the URL in the file view tab to ignore whitespace changes)

The unit tests pass `command.label` as `undefined` instead of `null`, which means the output of the `promote` command will be wrong in the unit tests.

@max-mironov, @sergey-akhalkov - this is not a customer-facing issue so it's not a big deal at all, and it's my fault for not mentioning it, but please make sure you run `gulp test` before you submit PR's, and maybe even add test cases if you can. This applies to the CLI and service repos only, as the test framework in the SDK repos is incomplete. Also, please review this change, and I can merge it after.