### PR TITLE
Updated deployment defaults. Now...

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -104,6 +104,7 @@ export interface IDebugCommand extends ICommand {
 export interface IDeploymentAddCommand extends ICommand {
     appName: string;
     deploymentName: string;
+    default: boolean;
 }
 
 export interface IDeploymentHistoryClearCommand extends ICommand {

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -284,8 +284,10 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .demand(/*count*/ 2, /*max*/ 2)  // Require exactly two non-option arguments.
             .command("add", "Add a new deployment to an app", (yargs: yargs.Argv): void => {
                 isValidCommand = true;
-                yargs.usage(USAGE_PREFIX + " deployment add <appName> <deploymentName>")
-                    .demand(/*count*/ 2, /*max*/ 2)  // Require exactly two non-option arguments
+                yargs.usage(USAGE_PREFIX + " deployment add <appName> [deploymentName]")
+                    .demand(/*count*/ 1, /*max*/ 2)  // Require the app name, with deploymentName optional (either deploymentName or --default needs to be specified)
+                    .option("default", { alias: "d", demand: false, description: "Add the default \"Staging\" and \"Production\" deployments",  type: "boolean" })
+                    .example("deployment add MyApp --default", "Adds default \"Staging\" and \"Production\" deployments to app \"MyApp\"")
                     .example("deployment add MyApp MyDeployment", "Adds deployment \"MyDeployment\" to app \"MyApp\"");
 
                 addCommonConfiguration(yargs);
@@ -645,13 +647,14 @@ function createCommand(): cli.ICommand {
             case "deployment":
                 switch (arg1) {
                     case "add":
-                        if (arg2 && arg3) {
+                        if (arg2 && (arg3 || argv["default"])) {
                             cmd = { type: cli.CommandType.deploymentAdd };
 
                             var deploymentAddCommand = <cli.IDeploymentAddCommand>cmd;
 
                             deploymentAddCommand.appName = arg2;
                             deploymentAddCommand.deploymentName = arg3;
+                            deploymentAddCommand.default = argv["default"];
                         }
                         break;
 

--- a/cli/test/cli.ts
+++ b/cli/test/cli.ts
@@ -74,11 +74,12 @@ export class SdkStub {
         });
     }
 
-    public addApp(name: string, os: string, platform: string): Promise<codePush.App> {
+    public addApp(name: string, os: string, platform: string, manuallyProvisionDeployments: boolean = false): Promise<codePush.App> {
         return Q(<codePush.App>{
             name: name,
             os: os,
-            platform: platform
+            platform: platform,
+            manuallyProvisionDeployments: manuallyProvisionDeployments
         });
     }
 
@@ -665,7 +666,8 @@ describe("CLI", () => {
         var command: cli.IDeploymentAddCommand = {
             type: cli.CommandType.deploymentAdd,
             appName: "a",
-            deploymentName: "b"
+            deploymentName: "b",
+            default: false
         };
 
         var addDeployment: Sinon.SinonSpy = sandbox.spy(cmdexec.sdk, "addDeployment");

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -9,7 +9,7 @@ import * as yazl from "yazl";
 
 import Promise = Q.Promise;
 
-import { AccessKey, AccessKeyRequest, Account, App, CodePushError, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Headers, Package, PackageInfo, ServerAccessKey, Session, UpdateMetrics } from "./types";
+import { AccessKey, AccessKeyRequest, Account, App, AppCreationRequest, CodePushError, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Headers, Package, PackageInfo, ServerAccessKey, Session, UpdateMetrics } from "./types";
 
 var superproxy = require("superagent-proxy");
 superproxy(superagent);
@@ -214,11 +214,12 @@ class AccountManager {
             .then((res: JsonResponse) => res.body.app);
     }
 
-    public addApp(appName: string, appOs: string, appPlatform: string): Promise<App> {
-        var app: App = {
+    public addApp(appName: string, appOs: string, appPlatform: string, manuallyProvisionDeployments: boolean = false): Promise<App> {
+        var app: AppCreationRequest = {
             name: appName,
             os: appOs,
-            platform: appPlatform
+            platform: appPlatform,
+            manuallyProvisionDeployments: manuallyProvisionDeployments
         };
         return this.post(urlEncode `/apps/`, JSON.stringify(app), /*expectResponseBody=*/ false)
             .then(() => app);

--- a/sdk/script/types.ts
+++ b/sdk/script/types.ts
@@ -1,4 +1,4 @@
-export { AccessKeyRequest, Account, App, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Package, PackageInfo, AccessKey as ServerAccessKey, UpdateMetrics } from "rest-definitions";
+export { AccessKeyRequest, Account, App, AppCreationRequest, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Package, PackageInfo, AccessKey as ServerAccessKey, UpdateMetrics } from "rest-definitions";
 
 export interface CodePushError {
     message: string;


### PR DESCRIPTION
* "code-push add add" does NOT add any default deployments
* "code-push deployment add" has a --default option to add default deployments
* "code-push release" outputs a more descriptive error if no deployments exists