### PR TITLE
Update gradle-to-js

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,7 @@
     "cli-table": "^0.3.1",
     "code-push": "2.0.2-beta",
     "email-validator": "^1.0.3",
-    "gradle-to-js": "0.2.5",
+    "gradle-to-js": "^1.0.1",
     "jsonwebtoken": "^7.4.1",
     "moment": "^2.10.6",
     "opener": "^1.4.1",

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -975,19 +975,7 @@ function getReactNativeProjectAppVersion(command: cli.IReleaseReactCommand, proj
             .then((buildGradle: any) => {
                 let versionName: string = null;
 
-                // First 'if' statement was implemented as workaround for case
-                // when 'build.gradle' file contains several 'android' nodes.
-                // In this case 'buildGradle.android' prop represents array instead of object
-                // due to parsing issue in 'g2js.parseFile' method.
-                if (buildGradle.android instanceof Array) {
-                    for (var i = 0; i < buildGradle.android.length; i++) {
-                        var gradlePart = buildGradle.android[i];
-                        if (gradlePart.defaultConfig && gradlePart.defaultConfig.versionName) {
-                            versionName = gradlePart.defaultConfig.versionName;
-                            break;
-                        }
-                    }
-                } else if (buildGradle.android && buildGradle.android.defaultConfig && buildGradle.android.defaultConfig.versionName) {
+                if (buildGradle.android && buildGradle.android.defaultConfig && buildGradle.android.defaultConfig.versionName) {
                     versionName = buildGradle.android.defaultConfig.versionName;
                 } else {
                     throw new Error(`The "${buildGradlePath}" file doesn't specify a value for the "android.defaultConfig.versionName" property.`);


### PR DESCRIPTION
Important bugfix there ... https://github.com/ninetwozero/gradle-to-js/pull/9

There is no changelog, but based on list of commits, there is not much of changes from the currently used 0.2.5

Edit: On another look seeing the last comment there, something might be broken. Consider this PR as a starting point then :)