### PR TITLE
add privateKey support for release-cordova

### DIFF
--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -419,6 +419,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("noDuplicateReleaseError", { default: false, demand: false, description: "When this flag is set, releasing a package that is identical to the latest release will produce a warning instead of an error", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the config.xml file.", type: "string" })
+            .option("privateKeyPath", { alias: "k", default: false, demand: false, description: "Specifies the location of a RSA private key to sign the release with", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
         addCommonConfiguration(yargs);
@@ -831,6 +832,7 @@ function createCommand(): cli.ICommand {
                     releaseCordovaCommand.rollout = getRolloutValue(argv["rollout"]);
                     releaseCordovaCommand.appStoreVersion = argv["targetBinaryVersion"];
                     releaseCordovaCommand.isReleaseBuildType = argv["isReleaseBuildType"];
+                    releaseCordovaCommand.privateKeyPath = argv["privateKeyPath"];
                 }
                 break;
 

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -398,7 +398,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("description", { alias: "des", default: null, demand: false, description: "Description of the changes made to the app in this release", type: "string" })
             .option("disabled", { alias: "x", default: false, demand: false, description: "Specifies whether this release should be immediately downloadable", type: "boolean" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Specifies whether this release should be considered mandatory", type: "boolean" })
-            .option("privateKeyPath", { alias: "k", default: false, demand: false, description: "Specifies the location of a RSA private key to sign the release with. " + chalk.yellow("NOTICE:") + " use it for react native applications only, client SDK on other platforms will be ignoring signature verification for now!", type: "string" })
+            .option("privateKeyPath", { alias: "k", default: false, demand: false, description: "Specifies the location of a RSA private key to sign the release with", type: "string" })
             .option("noDuplicateReleaseError", { default: false, demand: false, description: "When this flag is set, releasing a package that is identical to the latest release will produce a warning instead of an error", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be available to", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
@@ -416,10 +416,10 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("description", { alias: "des", default: null, demand: false, description: "Description of the changes made to the app in this release", type: "string" })
             .option("disabled", { alias: "x", default: false, demand: false, description: "Specifies whether this release should be immediately downloadable", type: "boolean" })
             .option("mandatory", { alias: "m", default: false, demand: false, description: "Specifies whether this release should be considered mandatory", type: "boolean" })
+            .option("privateKeyPath", { alias: "k", default: false, demand: false, description: "Specifies the location of a RSA private key to sign the release with", type: "string" })
             .option("noDuplicateReleaseError", { default: false, demand: false, description: "When this flag is set, releasing a package that is identical to the latest release will produce a warning instead of an error", type: "boolean" })
             .option("rollout", { alias: "r", default: "100%", demand: false, description: "Percentage of users this release should be immediately available to", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the config.xml file.", type: "string" })
-            .option("privateKeyPath", { alias: "k", default: false, demand: false, description: "Specifies the location of a RSA private key to sign the release with", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
         addCommonConfiguration(yargs);

--- a/cli/script/release-hooks/signing.ts
+++ b/cli/script/release-hooks/signing.ts
@@ -10,7 +10,7 @@ var rimraf = require("rimraf");
 import AccountManager = require("code-push");
 
 var CURRENT_CLAIM_VERSION: string = "1.0.0";
-var METADATA_FILE_NAME: string = ".codepushrelease"
+var METADATA_FILE_NAME: string = ".codepushrelease";
 
 interface CodeSigningClaims {
     claimVersion: string;
@@ -22,8 +22,13 @@ var sign: cli.ReleaseHook = (currentCommand: cli.IReleaseCommand, originalComman
         if (fs.lstatSync(currentCommand.package).isDirectory()) {
             // If new update wasn't signed, but signature file for some reason still appears in the package directory - delete it
             let signatureFilePath = path.join(currentCommand.package, METADATA_FILE_NAME);
-            if (fs.existsSync(signatureFilePath)) {
-                fs.unlinkSync(signatureFilePath);
+            try {
+                if (fs.existsSync(signatureFilePath)) {
+                    fs.unlinkSync(signatureFilePath);
+                }
+            } catch(e) {
+                return q.reject<cli.IReleaseCommand>(new Error(`Could not delete redundant signature file ("${signatureFilePath}").
+                Please make sure you have correct permissions for this file.`));
             }
         }
 

--- a/cli/script/release-hooks/signing.ts
+++ b/cli/script/release-hooks/signing.ts
@@ -19,6 +19,14 @@ interface CodeSigningClaims {
 
 var sign: cli.ReleaseHook = (currentCommand: cli.IReleaseCommand, originalCommand: cli.IReleaseCommand, sdk: AccountManager): q.Promise<cli.IReleaseCommand> => {
     if (!currentCommand.privateKeyPath) {
+        if (fs.lstatSync(currentCommand.package).isDirectory()) {
+            // If new update wasn't signed, but signature file for some reason still appears in the package directory - delete it
+            let signatureFilePath = path.join(currentCommand.package, METADATA_FILE_NAME);
+            if (fs.existsSync(signatureFilePath)) {
+                fs.unlinkSync(signatureFilePath);
+            }
+        }
+
         return q.resolve<cli.IReleaseCommand>(currentCommand);
     }
 

--- a/cli/script/release-hooks/signing.ts
+++ b/cli/script/release-hooks/signing.ts
@@ -17,9 +17,9 @@ interface CodeSigningClaims {
     contentHash: string;
 }
 
-var deletePreviousSignatureIfExists = (command: cli.IReleaseCommand): q.Promise<any> => {
-    var signatureFilePath = path.join(command.package, METADATA_FILE_NAME);
-    var prevSignatureExists = true;
+const deletePreviousSignatureIfExists = (package: string): q.Promise<any> => {
+    let signatureFilePath: string = path.join(package, METADATA_FILE_NAME);
+    let prevSignatureExists: boolean = true;
     try {
         fs.accessSync(signatureFilePath, fs.R_OK);
     } catch (err) {
@@ -38,7 +38,7 @@ var deletePreviousSignatureIfExists = (command: cli.IReleaseCommand): q.Promise<
         rimraf.sync(signatureFilePath);
     }
 
-    return q.resolve<cli.IReleaseCommand>(command);
+    return q.resolve(<void>null);
 }
 
 var sign: cli.ReleaseHook = (currentCommand: cli.IReleaseCommand, originalCommand: cli.IReleaseCommand, sdk: AccountManager): q.Promise<cli.IReleaseCommand> => {
@@ -46,7 +46,7 @@ var sign: cli.ReleaseHook = (currentCommand: cli.IReleaseCommand, originalComman
     if (!currentCommand.privateKeyPath) {
         if (fs.lstatSync(currentCommand.package).isDirectory()) {
             // If new update wasn't signed, but signature file for some reason still appears in the package directory - delete it
-            return deletePreviousSignatureIfExists(currentCommand).then(() => {
+            return deletePreviousSignatureIfExists(currentCommand.package).then(() => {
                 return q.resolve<cli.IReleaseCommand>(currentCommand); 
             });
         } else {
@@ -54,8 +54,8 @@ var sign: cli.ReleaseHook = (currentCommand: cli.IReleaseCommand, originalComman
         }   
     }
 
-    var privateKey: Buffer;
-    var signatureFilePath: string;
+    let privateKey: Buffer;
+    let signatureFilePath: string;
 
     return q(<void>null)
         .then(() => {
@@ -78,7 +78,7 @@ var sign: cli.ReleaseHook = (currentCommand: cli.IReleaseCommand, originalComman
                 currentCommand.package = outputFolderPath;
             }
 
-            return deletePreviousSignatureIfExists(currentCommand);    
+            return deletePreviousSignatureIfExists(currentCommand.package);    
         })
         .then(() => {
             return hashUtils.generatePackageHashFromDirectory(currentCommand.package, path.join(currentCommand.package, ".."));


### PR DESCRIPTION
In preparation for code-signing support for cordova, the code-push cli should support the -k option for the `release-cordova` command as well.