### PR TITLE
Update return type of management sdk release method

### DIFF
--- a/cli/script/release-hooks/core-release.ts
+++ b/cli/script/release-hooks/core-release.ts
@@ -15,7 +15,7 @@ import * as yazl from "yazl";
 var progress = require("progress");
 
 import AccountManager = require("code-push");
-import {PackageInfo} from "code-push/script/types";
+import {Package, PackageInfo} from "code-push/script/types";
 import {CommonUtils} from "../common-utils";
 var log = CommonUtils.log;
 import * as cli from "../../definitions/cli";
@@ -105,7 +105,7 @@ var coreReleaseHook: cli.ReleaseHook = (currentCommand: cli.IReleaseCommand, ori
             };
 
             return sdk.isAuthenticated(true)
-                .then((isAuth: boolean): Promise<void> => {
+                .then((isAuth: boolean): Promise<Package> => {
                     return sdk.release(currentCommand.appName, currentCommand.deploymentName, packagePath, currentCommand.appStoreVersion, updateMetadata, uploadProgress);
                 })
                 .then((): void => {

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -71,7 +71,7 @@ The `code-push` module exports a single class (typically referred to as `CodePus
 
 - __promote(appName: string, sourceDeploymentName: string, destinationDeploymentName: string, updateMetadata: PackageInfo): Promise&lt;void&gt;__ - Promotes the latest release from one deployment to another for the specified app and updates the release with the given metadata.
 
-- __release(appName: string, deploymentName: string, updateContentsPath: string, targetBinaryVersion: string, updateMetadata: PackageInfo): Promise&lt;void&gt;__ - Releases a new update to the specified deployment with the given metadata.
+- __release(appName: string, deploymentName: string, updateContentsPath: string, targetBinaryVersion: string, updateMetadata: PackageInfo): Promise&lt;Package&gt;__ - Releases a new update to the specified deployment with the given metadata.
 
 - __removeAccessKey(accessKey: string): Promise&lt;void&gt;__ - Removes the specified access key from your CodePush account.
 

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -331,19 +331,17 @@ class AccountManager {
                             return;
                         }
 
-                        if (res.ok) {
-                            resolve(<Package>(JSON.parse(res.text).package));
-                        } else {
-                            try {
-                                var body = JSON.parse(res.text);
-                            } catch (err) {
-                            }
+                        try {
+                            var body = JSON.parse(res.text);
+                        } catch (err) {
+                            reject(<CodePushError>{ message: `Could not parse response: ${res.text}`, statusCode: AccountManager.ERROR_INTERNAL_SERVER });
+                            return;
+                        }
 
-                            if (body) {
-                                reject(<CodePushError>{ message: body.message, statusCode: res && res.status });
-                            } else {
-                                reject(<CodePushError>{ message: res.text, statusCode: res && res.status });
-                            }
+                        if (res.ok) {
+                            resolve(<Package>body.package);
+                        } else {
+                            reject(<CodePushError>{ message: body.message, statusCode: res && res.status });
                         }
                     });
             });

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -299,9 +299,9 @@ class AccountManager {
             .then((res: JsonResponse) => res.body.history);
     }
 
-    public release(appName: string, deploymentName: string, filePath: string, targetBinaryVersion: string, updateMetadata: PackageInfo, uploadProgressCallback?: (progress: number) => void): Promise<void> {
+    public release(appName: string, deploymentName: string, filePath: string, targetBinaryVersion: string, updateMetadata: PackageInfo, uploadProgressCallback?: (progress: number) => void): Promise<Package> {
 
-        return Promise<void>((resolve, reject, notify) => {
+        return Promise<Package>((resolve, reject, notify) => {
 
             updateMetadata.appVersion = targetBinaryVersion;
             var request: superagent.Request<any> = superagent.post(this._serverUrl + urlEncode `/apps/${this.appNameParam(appName)}/deployments/${deploymentName}/release`);
@@ -332,7 +332,7 @@ class AccountManager {
                         }
 
                         if (res.ok) {
-                            resolve(<void>null);
+                            resolve(<Package>(JSON.parse(res.text).package));
                         } else {
                             try {
                                 var body = JSON.parse(res.text);


### PR DESCRIPTION
This PR updates the return type of the management sdk `release` method, to return a `Promise<Package>` instead of a `Promise<void>`.

To conduct some code push automation part of a project, we need to get back the `label` that was created following a deployment through `release` method code. Unfortunately, because the `release` method is returning a `Promise<void>` we don't get this information back, even though it is contained within the successful server response.

Looking at the response payload we get back from the server following a successful deployment through `release` method call,

```json
{
    "package": {
        "isMandatory": true,
        "appVersion": "1.0",
        "packageHash": "3fc3828e674d8903fdc7c0dd4924938946f6b76314e1317cdef10fa946b89060",
        "blobUrl": "https://codepush.blob.core.windows.net/storagev2/wb2Ee7_OpeMx67tr2hxoeJRhYaZe4a9b7d8f-80d4-459f-b625-566c1ae80af1",
        "size": 145160,
        "releaseMethod": "Upload",
        "uploadTime": 1510263394211,
        "label": "v4",
        "releasedBy": "lemaireb@gmail.com",
        "rollout": 100
    }
}
```

I figured out that the `package` object returned was matching the [Package type]( https://github.com/Microsoft/code-push/blob/19c6f2442e31c73ebb499b07cb1f903c151bacdd/definitions/rest-definitions.d.ts#L147)

It makes sense to return this object instead of `void`, as it contains the `label` along with other interesting information that can be used/stored if needed (or even logged to the user in some way when releasing through CLI command).