### PR TITLE
Update return type of SDK promote method 

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -69,7 +69,7 @@ The `code-push` module exports a single class (typically referred to as `CodePus
 
 - __patchRelease(appName: string, deploymentName: string, label: string, updateMetadata: PackageInfo): Promise&lt;void&gt;__ - Updates the specified release's metadata with the given information.
 
-- __promote(appName: string, sourceDeploymentName: string, destinationDeploymentName: string, updateMetadata: PackageInfo): Promise&lt;void&gt;__ - Promotes the latest release from one deployment to another for the specified app and updates the release with the given metadata.
+- __promote(appName: string, sourceDeploymentName: string, destinationDeploymentName: string, updateMetadata: PackageInfo): Promise&lt;Package&gt;__ - Promotes the latest release from one deployment to another for the specified app and updates the release with the given metadata.
 
 - __release(appName: string, deploymentName: string, updateContentsPath: string, targetBinaryVersion: string, updateMetadata: PackageInfo): Promise&lt;Package&gt;__ - Releases a new update to the specified deployment with the given metadata.
 

--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -355,10 +355,10 @@ class AccountManager {
             .then(() => null);
     }
 
-    public promote(appName: string, sourceDeploymentName: string, destinationDeploymentName: string,  updateMetadata: PackageInfo): Promise<void> {
+    public promote(appName: string, sourceDeploymentName: string, destinationDeploymentName: string,  updateMetadata: PackageInfo): Promise<Package> {
         var requestBody: string = JSON.stringify({ packageInfo: updateMetadata });
-        return this.post(urlEncode `/apps/${this.appNameParam(appName)}/deployments/${sourceDeploymentName}/promote/${destinationDeploymentName}`, requestBody, /*expectResponseBody=*/ false)
-            .then(() => null);
+        return this.post(urlEncode `/apps/${this.appNameParam(appName)}/deployments/${sourceDeploymentName}/promote/${destinationDeploymentName}`, requestBody, /*expectResponseBody=*/ true)
+            .then((res: JsonResponse) => res.body.package);
     }
 
     public rollback(appName: string, deploymentName: string, targetRelease?: string): Promise<void> {

--- a/sdk/test/management-sdk.ts
+++ b/sdk/test/management-sdk.ts
@@ -351,7 +351,8 @@ describe("Management SDK", () => {
 
         manager.promote("appName", "deploymentName", "newDeploymentName", { description: "newDescription" })
             .done((obj: any) => {
-                assert.ok(!obj);
+                assert.ok(obj);
+                assert.equal(obj.description, "newDescription")
                 done();
             }, rejectHandler);
     });


### PR DESCRIPTION
In continuation to my previous PR https://github.com/Microsoft/code-push/pull/533, this PR updates the return type of the SDK `promote` method to return the `Package` object part of the server response instead of returning `void`.

Part of an ongoing project, calling in the CodePush SDK, we need the data resulting from the promotion.

It seems that the server call associated to `promote` will always return a body with a package object resulting from the promotion. Even the test was mocking a response with a package, so it seems that the server will always return a package response body in case of success.
If not (I'm doubting it), what could be done is changing the return type to `Promise<Package|void>` and changing the `expectResponseBody` back to false, and return the response Package if present, otherwise don't return anything, and let the caller act accordingly. 