### PR TITLE
add cli option for project dir

### DIFF
--- a/cli/definitions/cli.ts
+++ b/cli/definitions/cli.ts
@@ -207,6 +207,7 @@ export interface IReleaseReactCommand extends IReleaseBaseCommand {
     plistFilePrefix?: string;
     sourcemapOutput?: string;
     outputDir?: string;
+    projectDir?: string;
     config?: string;
 }
 

--- a/cli/script/command-executor.ts
+++ b/cli/script/command-executor.ts
@@ -1218,8 +1218,8 @@ export var releaseCordova = (command: cli.IReleaseCordovaCommand): Promise<void>
             if (platform === "ios") {
                 outputFolder = path.join(platformFolder, "www");
             } else if (platform === "android") {
-                
-                // Since cordova-android 7 assets directory moved to android/app/src/main/assets instead of android/assets                
+
+                // Since cordova-android 7 assets directory moved to android/app/src/main/assets instead of android/assets
                 const outputFolderVer7 = path.join(platformFolder, "app", "src", "main", "assets", "www");
                 if (fs.existsSync(outputFolderVer7)) {
                     outputFolder = outputFolderVer7;
@@ -1293,10 +1293,11 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
     var bundleName: string = command.bundleName;
     var entryFile: string = command.entryFile;
     var outputFolder: string = command.outputDir || path.join(os.tmpdir(), "CodePush");
+    var projectDir: string = command.projectDir || process.cwd();
     var platform: string = command.platform = command.platform.toLowerCase();
     var releaseCommand: cli.IReleaseCommand = <any>command;
 
-    // we have to add "CodePush" root forlder to make update contents file structure 
+    // we have to add "CodePush" root forlder to make update contents file structure
     // to be compatible with React Native client SDK
     outputFolder = path.join(outputFolder, "CodePush");
     mkdirp.sync(outputFolder);
@@ -1323,19 +1324,19 @@ export var releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => 
             }
 
             try {
-                var projectPackageJson: any = require(path.join(process.cwd(), "package.json"));
+                var projectPackageJson: any = require(path.join(projectDir, "package.json"));
                 var projectName: string = projectPackageJson.name;
                 if (!projectName) {
-                    throw new Error("The \"package.json\" file in the CWD does not have the \"name\" field set.");
+                    throw new Error(`The \"package.json\" file in the projectDir (${projectDir}) does not have the \"name\" field set.`);
                 }
 
                 const isReactNativeProject: boolean = projectPackageJson.dependencies["react-native"] ||
                     (projectPackageJson.devDependencies && projectPackageJson.devDependencies["react-native"]);
                 if (!isReactNativeProject) {
-                    throw new Error("The project in the CWD is not a React Native project.");
+                    throw new Error(`The project in the projectDir (${projectDir}) is not a React Native project.`);
                 }
             } catch (error) {
-                throw new Error("Unable to find or read \"package.json\" in the CWD. The \"release-react\" command must be executed in a React Native project folder.");
+                throw new Error(`Unable to find or read \"package.json\" in ${projectDir}. The \"release-react\" command must be executed in a React Native project folder or you must specify its path with the --projectDir option.`);
             }
 
             if (!entryFile) {

--- a/cli/script/command-parser.ts
+++ b/cli/script/command-parser.ts
@@ -65,7 +65,7 @@ function accessKeyPatch(commandName: string, yargs: yargs.Argv): void {
 function accessKeyList(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
     yargs.usage(USAGE_PREFIX + " access-key " + commandName + " [options]")
-        .demand(/*count*/ 0, /*max*/ 0)  
+        .demand(/*count*/ 0, /*max*/ 0)
         .example("access-key " + commandName, "Lists your access keys in tabular format")
         .example("access-key " + commandName + " --format json", "Lists your access keys in JSON format")
         .option("format", { default: "table", demand: false, description: "Output format to display your access keys with (\"json\" or \"table\")", type: "string" });
@@ -92,7 +92,7 @@ function addCommonConfiguration(yargs: yargs.Argv): void {
 function appList(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
     yargs.usage(USAGE_PREFIX + " app " + commandName + " [options]")
-        .demand(/*count*/ 0, /*max*/ 0)  
+        .demand(/*count*/ 0, /*max*/ 0)
         .example("app " + commandName, "List your apps in tabular format")
         .example("app " + commandName + " --format json", "List your apps in JSON format")
         .option("format", { default: "table", demand: false, description: "Output format to display your apps with (\"json\" or \"table\")", type: "string" });
@@ -132,7 +132,7 @@ function removeCollaborator(commandName: string, yargs: yargs.Argv): void {
 function sessionList(commandName: string, yargs: yargs.Argv): void {
     isValidCommand = true;
     yargs.usage(USAGE_PREFIX + " session " + commandName + " [options]")
-        .demand(/*count*/ 0, /*max*/ 0)  
+        .demand(/*count*/ 0, /*max*/ 0)
         .example("session " + commandName, "Lists your sessions in tabular format")
         .example("session " + commandName + " --format json", "Lists your login sessions in JSON format")
         .option("format", { default: "table", demand: false, description: "Output format to display your login sessions with (\"json\" or \"table\")", type: "string" });
@@ -340,7 +340,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         isValidCommandCategory = true;
         isValidCommand = true;
         yargs.usage(USAGE_PREFIX + " logout")
-            .demand(/*count*/ 0, /*max*/ 0) 
+            .demand(/*count*/ 0, /*max*/ 0)
             .example("logout", "Logs out and ends your current session");
         addCommonConfiguration(yargs);
     })
@@ -446,7 +446,8 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
             .option("sourcemapOutput", { alias: "s", default: null, demand: false, description: "Path to where the sourcemap for the resulting bundle should be written. If omitted, a sourcemap will not be generated.", type: "string" })
             .option("targetBinaryVersion", { alias: "t", default: null, demand: false, description: "Semver expression that specifies the binary app version(s) this release is targeting (e.g. 1.1.0, ~1.2.3). If omitted, the release will target the exact version specified in the \"Info.plist\" (iOS), \"build.gradle\" (Android) or \"Package.appxmanifest\" (Windows) files.", type: "string" })
             .option("outputDir", { alias: "o", default: null, demand: false, description: "Path to where the bundle and sourcemap should be written. If omitted, a bundle and sourcemap will not be written.", type: "string" })
-            .option("config", { alias: "c", default: null, demand: false, description: "Path to the React Native CLI configuration file", type: "string" })    
+            .option("config", { alias: "c", default: null, demand: false, description: "Path to the React Native CLI configuration file", type: "string" })
+            .option("projectDir", { alias: "dir", default: null, demand: false, description: "Path to where the react-native module is installed. By default your current working dir", type: "string" })
             .check((argv: any, aliases: { [aliases: string]: string }): any => { return checkValidReleaseOptions(argv); });
 
         addCommonConfiguration(yargs);
@@ -478,7 +479,7 @@ var argv = yargs.usage(USAGE_PREFIX + " <command>")
         isValidCommandCategory = true;
         isValidCommand = true;
         yargs.usage(USAGE_PREFIX + " whoami")
-            .demand(/*count*/ 0, /*max*/ 0)  
+            .demand(/*count*/ 0, /*max*/ 0)
             .example("whoami", "Display the account info for the current login session");
         addCommonConfiguration(yargs);
     })
@@ -862,6 +863,7 @@ function createCommand(): cli.ICommand {
                     releaseReactCommand.privateKeyPath = argv["privateKeyPath"];
                     releaseReactCommand.sourcemapOutput = argv["sourcemapOutput"];
                     releaseReactCommand.outputDir = argv["outputDir"];
+                    releaseReactCommand.projectDir = argv["projectDir"];
                     releaseReactCommand.config = argv["config"];
                 }
                 break;


### PR DESCRIPTION
The motivation for this is that sometimes you want to be able to run the `release-react` command from some other directory (deploying in ci, etc) and it would be nice if you could just pass a cli option in that tells `codepush` where to find the react-native cli, rather than assuming the process is always run from that directory.