### PR TITLE
Fix button break line on Firefox

### DIFF
--- a/assets/stylesheets/ga.style.css
+++ b/assets/stylesheets/ga.style.css
@@ -77,6 +77,7 @@ p, span {
   width:135px;
   height:40px;
   line-height: 20px;
+  border: 0;
 }
 
 .ga-hero {


### PR DESCRIPTION
The "Visit App Center" button had a break line on Firefox

![screen shot 2018-10-07 at 9 00 23 pm](https://user-images.githubusercontent.com/2978730/46589952-0e051a80-ca75-11e8-97f8-5a27432ff69e.png)
