### PR TITLE
Replaced app store version with binary version in docs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -332,7 +332,7 @@ If you ever want an update to target multiple versions of the app store binary, 
 
 | Range Expression | Who gets the update                                                                    |
 |------------------|----------------------------------------------------------------------------------------|
-| `1.2.3`          | Only devices running the specific binary app store version `1.2.3` of your app         |
+| `1.2.3`          | Only devices running the specific binary version `1.2.3` of your app         |
 | `*`              | Any device configured to consume updates from your CodePush app                        |
 | `1.2.x`          | Devices running major version 1, minor version 2 and any patch version of your app     |
 | `1.2.3 - 1.2.7`  | Devices running any binary version between `1.2.3` (inclusive) and `1.2.7` (inclusive) |
@@ -763,7 +763,7 @@ code-push promote <appName> <sourceDeploymentName> <destDeploymentName>
 
 The `promote` command will create a new release for the destination deployment, which includes the **exact code and metadata** (description, mandatory and target binary version) from the latest release of the source deployment. While you could use the `release` command to "manually" migrate an update from one environment to another, the `promote` command has the following benefits:
 
-1. It's quicker, since you don't need to reassemble the release assets you want to publish or remember the description/app store version that are associated with the source deployment's release.
+1. It's quicker, since you don't need to reassemble the release assets you want to publish or remember the description/binary version that are associated with the source deployment's release.
 
 2. It's less error-prone, since the promote operation ensures that the exact thing that you already tested in the source deployment (e.g. `Staging`) will become active in the destination deployment (e.g. `Production`).
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -348,14 +348,14 @@ If you ever want an update to target multiple versions of the app store binary, 
 
 The following table outlines the version value that CodePush expects your update's semver range to satisfy for each respective app type:
 
-| Platform               | Source of app store version                                                  |
+| Platform               | Source of binary version                                                  |
 |------------------------|------------------------------------------------------------------------------|
 | Cordova                | The `<widget version>` attribute in the `config.xml` file                    |
 | React Native (Android) | The `android.defaultConfig.versionName` property in your `build.gradle` file |
 | React Native (iOS)     | The `CFBundleShortVersionString` key in the `Info.plist` file                |
 | React Native (Windows) | The `<Identity Version>` key in the `Package.appxmanifest` file                                |
 
-*NOTE: If the app store version in the metadata files are missing a patch version, e.g. `2.0`, it will be treated as having a patch version of `0`, i.e. `2.0 -> 2.0.0`. The same is true for app store version equal to plain integer number, `1` will be treated as `1.0.0` in this case.*
+*NOTE: If the binary version in the metadata files are missing a patch version, e.g. `2.0`, it will be treated as having a patch version of `0`, i.e. `2.0 -> 2.0.0`. The same is true for binary version equal to plain integer number, `1` will be treated as `1.0.0` in this case.*
 
 #### Deployment name parameter
 


### PR DESCRIPTION
*Issue*: Docs says `app store version` where should be `binary version` as it is more understandable for users.
*Solution:* Replaced app store version with binary version in docs.

Related issue: https://github.com/microsoft/code-push/issues/605