### PR TITLE
Update acquisition sdk to work with new service

### DIFF
--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -60,19 +60,18 @@ declare module "rest-definitions" {
     }
 
     /*out*/
-    export interface UpdateCheckResponse extends PackageInfo {
-        downloadURL?: string;
-        isAvailable: boolean;
-        packageSize?: number;
-        shouldRunBinaryVersion?: boolean;
-        updateAppVersion?: boolean;
-    }
-
-    /*out*/
-    export interface UpdateCheckCacheResponse {
-        originalPackage: UpdateCheckResponse;
-        rollout?: number;
-        rolloutPackage?: UpdateCheckResponse;
+    export interface UpdateCheckResponse {
+        download_url?: string;
+        description?: string;
+        is_available: boolean;
+        is_disabled?: boolean;
+        target_binary_range: string;
+        /*generated*/ label?: string;
+        /*generated*/ package_hash?: string;
+        package_size?: number;
+        should_run_binary_version?: boolean;
+        update_app_version?: boolean;
+        is_mandatory?: boolean;
     }
 
     /*in*/

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -77,12 +77,12 @@ declare module "rest-definitions" {
 
     /*in*/
     export interface UpdateCheckRequest {
-        appVersion: string;
-        clientUniqueId?: string;
-        deploymentKey: string;
-        isCompanion?: boolean;
+        app_version: string;
+        client_unique_id?: string;
+        deployment_key: string;
+        is_companion?: boolean;
         label?: string;
-        packageHash?: string;
+        package_hash?: string;
     }
 
     /*out*/

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -43,8 +43,8 @@ declare module "rest-definitions" {
 
     /*in*/
     export interface DownloadReport {
-        clientUniqueId: string;
-        deploymentKey: string;
+        client_unique_id: string;
+        deployment_key: string;
         label: string;
     }
 

--- a/definitions/rest-definitions.d.ts
+++ b/definitions/rest-definitions.d.ts
@@ -32,11 +32,11 @@ declare module "rest-definitions" {
 
     /*in*/
     export interface DeploymentStatusReport {
-        appVersion: string;
-        clientUniqueId?: string;
-        deploymentKey: string;
-        previousDeploymentKey?: string;
-        previousLabelOrAppVersion?: string;
+        app_version: string;
+        client_unique_id?: string;
+        deployment_key: string;
+        previous_deployment_key?: string;
+        previous_label_or_app_version?: string;
         label?: string;
         status?: string;
     }

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -86,15 +86,15 @@ export class AcquisitionManager {
         }
 
         var updateRequest: UpdateCheckRequest = {
-            deploymentKey: this._deploymentKey,
-            appVersion: currentPackage.appVersion,
-            packageHash: currentPackage.packageHash,
-            isCompanion: this._ignoreAppVersion,
+            deployment_key: this._deploymentKey,
+            app_version: currentPackage.appVersion,
+            package_hash: currentPackage.packageHash,
+            is_companion: this._ignoreAppVersion,
             label: currentPackage.label,
-            clientUniqueId: this._clientUniqueId
+            client_unique_id: this._clientUniqueId
         };
 
-        var requestUrl: string = this._serverUrl + "updateCheck?" + queryStringify(updateRequest);
+        var requestUrl: string = this._serverUrl + "update_check?" + queryStringify(updateRequest);
 
         this._httpRequester.request(Http.Verb.GET, requestUrl, (error: Error, response: Http.Response) => {
             if (error) {

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -207,10 +207,10 @@ export class AcquisitionManager {
     }
 
     public reportStatusDownload(downloadedPackage: Package, callback?: Callback<void>): void {
-        var url: string = this._serverUrl + "reportStatus/download";
+        var url: string = this._serverUrl + "report_status/download";
         var body: DownloadReport = {
-            clientUniqueId: this._clientUniqueId,
-            deploymentKey: this._deploymentKey,
+            client_unique_id: this._clientUniqueId,
+            deployment_key: this._deploymentKey,
             label: downloadedPackage.label
         };
 
@@ -239,12 +239,12 @@ function queryStringify(object: Object): string {
     for (var property in object) {
         if (object.hasOwnProperty(property)) {
             var value: string = (<any>object)[property];
-            if (!isFirst) {
-                queryString += "&";
-            }
-
-            queryString += encodeURIComponent(property) + "=";
             if (value !== null && typeof value !== "undefined") {
+                if (!isFirst) {
+                    queryString += "&";
+                }
+
+                queryString += encodeURIComponent(property) + "=";
                 queryString += encodeURIComponent(value);
             }
 

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -123,10 +123,10 @@ export class AcquisitionManager {
             if (!updateInfo) {
                 callback(error, /*remotePackage=*/ null);
                 return;
-            } else if (updateInfo.updateAppVersion) {
-                callback(/*error=*/ null, { updateAppVersion: true, appVersion: updateInfo.appVersion });
+            } else if (updateInfo.update_app_version) {
+                callback(/*error=*/ null, { updateAppVersion: true, appVersion: updateInfo.target_binary_range });
                 return;
-            } else if (!updateInfo.isAvailable) {
+            } else if (!updateInfo.is_available) {
                 callback(/*error=*/ null, /*remotePackage=*/ null);
                 return;
             }
@@ -135,11 +135,11 @@ export class AcquisitionManager {
                 deploymentKey: this._deploymentKey,
                 description: updateInfo.description,
                 label: updateInfo.label,
-                appVersion: updateInfo.appVersion,
-                isMandatory: updateInfo.isMandatory,
-                packageHash: updateInfo.packageHash,
-                packageSize: updateInfo.packageSize,
-                downloadUrl: updateInfo.downloadURL
+                appVersion: updateInfo.target_binary_range,
+                isMandatory: updateInfo.is_mandatory,
+                packageHash: updateInfo.package_hash,
+                packageSize: updateInfo.package_size,
+                downloadUrl: updateInfo.download_url
             };
 
             callback(/*error=*/ null, remotePackage);

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -147,19 +147,19 @@ export class AcquisitionManager {
     }
 
     public reportStatusDeploy(deployedPackage?: Package, status?: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string, callback?: Callback<void>): void {
-        var url: string = this._serverUrl + "reportStatus/deploy";
+        var url: string = this._serverUrl + "report_status/deploy";
         var body: DeploymentStatusReport = {
-            appVersion: this._appVersion,
-            deploymentKey: this._deploymentKey
+            app_version: this._appVersion,
+            deployment_key: this._deploymentKey
         };
 
         if (this._clientUniqueId) {
-            body.clientUniqueId = this._clientUniqueId;
+            body.client_unique_id = this._clientUniqueId;
         }
 
         if (deployedPackage) {
             body.label = deployedPackage.label;
-            body.appVersion = deployedPackage.appVersion;
+            body.app_version = deployedPackage.appVersion;
 
             switch (status) {
                 case AcquisitionStatus.DeploymentSucceeded:
@@ -180,11 +180,11 @@ export class AcquisitionManager {
         }
 
         if (previousLabelOrAppVersion) {
-            body.previousLabelOrAppVersion = previousLabelOrAppVersion;
+            body.previous_label_or_app_version = previousLabelOrAppVersion;
         }
 
         if (previousDeploymentKey) {
-            body.previousDeploymentKey = previousDeploymentKey;
+            body.previous_deployment_key = previousDeploymentKey;
         }
 
         callback = typeof arguments[arguments.length - 1] === "function" && arguments[arguments.length - 1];

--- a/sdk/test/acquisition-rest-mock.ts
+++ b/sdk/test/acquisition-rest-mock.ts
@@ -8,15 +8,15 @@ import * as rest from "rest-definitions";
 
 export var validDeploymentKey = "asdfasdfawerqw";
 export var latestPackage = <rest.UpdateCheckResponse>{
-    downloadURL: "http://www.windowsazure.com/blobs/awperoiuqpweru",
+    download_url: "http://www.windowsazure.com/blobs/awperoiuqpweru",
     description: "Angry flappy birds",
-    appVersion: "1.5.0",
+    target_binary_range: "1.5.0",
     label: "2.4.0",
-    isMandatory: false,
-    isAvailable: true,
-    updateAppVersion: false,
-    packageHash: "hash240",
-    packageSize: 1024
+    is_mandatory: false,
+    is_available: true,
+    update_app_version: false,
+    package_hash: "hash240",
+    package_size: 1024
 };
 
 export var serverUrl = "http://myurl.com";
@@ -87,14 +87,14 @@ class Server {
         if (!updateRequest.deployment_key || !updateRequest.app_version) {
             callback(/*error=*/ null, { statusCode: 400 });
         } else {
-            var updateInfo = <rest.UpdateCheckResponse>{ isAvailable: false };
+            var updateInfo = <rest.UpdateCheckResponse>{ is_available: false };
             if (updateRequest.deployment_key === validDeploymentKey) {
-                if (updateRequest.is_companion || updateRequest.app_version === latestPackage.appVersion) {
-                    if (updateRequest.package_hash !== latestPackage.packageHash) {
+                if (updateRequest.is_companion || updateRequest.app_version === latestPackage.target_binary_range) {
+                    if (updateRequest.package_hash !== latestPackage.package_hash) {
                         updateInfo = latestPackage;
                     }
-                } else if (updateRequest.app_version < latestPackage.appVersion) {
-                    updateInfo = <rest.UpdateCheckResponse><any>{ updateAppVersion: true, appVersion: latestPackage.appVersion };
+                } else if (updateRequest.app_version < latestPackage.target_binary_range) {
+                    updateInfo = <rest.UpdateCheckResponse><any>{ updateAppVersion: true, appVersion: latestPackage.target_binary_range };
                 }
             }
 

--- a/sdk/test/acquisition-rest-mock.ts
+++ b/sdk/test/acquisition-rest-mock.ts
@@ -77,23 +77,23 @@ class Server {
 
     public static onUpdateCheck(params: any, callback: acquisitionSdk.Callback<acquisitionSdk.Http.Response>): void {
         var updateRequest: rest.UpdateCheckRequest = {
-            deploymentKey: params.deploymentKey,
-            appVersion: params.appVersion,
-            packageHash: params.packageHash,
-            isCompanion: !!(params.isCompanion),
+            deployment_key: params.deploymentKey,
+            app_version: params.appVersion,
+            package_hash: params.packageHash,
+            is_companion: !!(params.isCompanion),
             label: params.label
         };
 
-        if (!updateRequest.deploymentKey || !updateRequest.appVersion) {
+        if (!updateRequest.deployment_key || !updateRequest.app_version) {
             callback(/*error=*/ null, { statusCode: 400 });
         } else {
             var updateInfo = <rest.UpdateCheckResponse>{ isAvailable: false };
-            if (updateRequest.deploymentKey === validDeploymentKey) {
-                if (updateRequest.isCompanion || updateRequest.appVersion === latestPackage.appVersion) {
-                    if (updateRequest.packageHash !== latestPackage.packageHash) {
+            if (updateRequest.deployment_key === validDeploymentKey) {
+                if (updateRequest.is_companion || updateRequest.app_version === latestPackage.appVersion) {
+                    if (updateRequest.package_hash !== latestPackage.packageHash) {
                         updateInfo = latestPackage;
                     }
-                } else if (updateRequest.appVersion < latestPackage.appVersion) {
+                } else if (updateRequest.app_version < latestPackage.appVersion) {
                     updateInfo = <rest.UpdateCheckResponse><any>{ updateAppVersion: true, appVersion: latestPackage.appVersion };
                 }
             }

--- a/sdk/test/acquisition-rest-mock.ts
+++ b/sdk/test/acquisition-rest-mock.ts
@@ -20,7 +20,7 @@ export var latestPackage = <rest.UpdateCheckResponse>{
 };
 
 export var serverUrl = "http://myurl.com";
-var reportStatusDeployUrl = serverUrl + "/reportStatus/deploy";
+var reportStatusDeployUrl = serverUrl + "/report_status/deploy";
 var reportStatusDownloadUrl = serverUrl + "/reportStatus/download";
 var updateCheckUrl = serverUrl + "/update_check?";
 

--- a/sdk/test/acquisition-rest-mock.ts
+++ b/sdk/test/acquisition-rest-mock.ts
@@ -50,7 +50,7 @@ export class CustomResponseHttpRequester implements acquisitionSdk.Http.Requeste
         this.response = response;
     }
 
-    public request(verb: acquisitionSdk.Http.Verb, url: string, requestBodyOrCallback: string|acquisitionSdk.Callback<acquisitionSdk.Http.Response>, callback?: acquisitionSdk.Callback<acquisitionSdk.Http.Response>): void {
+    public request(verb: acquisitionSdk.Http.Verb, url: string, requestBodyOrCallback: string | acquisitionSdk.Callback<acquisitionSdk.Http.Response>, callback?: acquisitionSdk.Callback<acquisitionSdk.Http.Response>): void {
         if (typeof requestBodyOrCallback !== "function") {
             throw new Error("Unexpected request body");
         }

--- a/sdk/test/acquisition-rest-mock.ts
+++ b/sdk/test/acquisition-rest-mock.ts
@@ -22,7 +22,7 @@ export var latestPackage = <rest.UpdateCheckResponse>{
 export var serverUrl = "http://myurl.com";
 var reportStatusDeployUrl = serverUrl + "/reportStatus/deploy";
 var reportStatusDownloadUrl = serverUrl + "/reportStatus/download";
-var updateCheckUrl = serverUrl + "/updateCheck?";
+var updateCheckUrl = serverUrl + "/update_check?";
 
 export class HttpRequester implements acquisitionSdk.Http.Requester {
     public request(verb: acquisitionSdk.Http.Verb, url: string, requestBodyOrCallback: string | acquisitionSdk.Callback<acquisitionSdk.Http.Response>, callback?: acquisitionSdk.Callback<acquisitionSdk.Http.Response>): void {
@@ -77,10 +77,10 @@ class Server {
 
     public static onUpdateCheck(params: any, callback: acquisitionSdk.Callback<acquisitionSdk.Http.Response>): void {
         var updateRequest: rest.UpdateCheckRequest = {
-            deployment_key: params.deploymentKey,
-            app_version: params.appVersion,
-            package_hash: params.packageHash,
-            is_companion: !!(params.isCompanion),
+            deployment_key: params.deployment_key,
+            app_version: params.app_version,
+            package_hash: params.package_hash,
+            is_companion: !!(params.is_companion),
             label: params.label
         };
 
@@ -94,7 +94,7 @@ class Server {
                         updateInfo = latestPackage;
                     }
                 } else if (updateRequest.app_version < latestPackage.target_binary_range) {
-                    updateInfo = <rest.UpdateCheckResponse><any>{ updateAppVersion: true, appVersion: latestPackage.target_binary_range };
+                    updateInfo = <rest.UpdateCheckResponse><any>{ update_app_version: true, target_binary_range: latestPackage.target_binary_range };
                 }
             }
 

--- a/sdk/test/acquisition-rest-mock.ts
+++ b/sdk/test/acquisition-rest-mock.ts
@@ -21,7 +21,7 @@ export var latestPackage = <rest.UpdateCheckResponse>{
 
 export var serverUrl = "http://myurl.com";
 var reportStatusDeployUrl = serverUrl + "/report_status/deploy";
-var reportStatusDownloadUrl = serverUrl + "/reportStatus/download";
+var reportStatusDownloadUrl = serverUrl + "/report_status/download";
 var updateCheckUrl = serverUrl + "/update_check?";
 
 export class HttpRequester implements acquisitionSdk.Http.Requester {

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -115,7 +115,7 @@ describe("Acquisition SDK", () => {
         };
 
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(emptyReponse), configuration);
-        acquisition.queryUpdateWithCurrentPackage(lowerAppVersionPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage|acquisitionSdk.NativeUpdateNotification) => {
+        acquisition.queryUpdateWithCurrentPackage(lowerAppVersionPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
             assert.equal(null, error);
             done();
         });
@@ -131,7 +131,7 @@ describe("Acquisition SDK", () => {
         };
 
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(unexpectedResponse), configuration);
-        acquisition.queryUpdateWithCurrentPackage(lowerAppVersionPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage|acquisitionSdk.NativeUpdateNotification) => {
+        acquisition.queryUpdateWithCurrentPackage(lowerAppVersionPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
             assert.equal(null, error);
             done();
         });
@@ -188,7 +188,7 @@ describe("Acquisition SDK", () => {
         };
 
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(invalidJsonReponse), configuration);
-        acquisition.queryUpdateWithCurrentPackage(lowerAppVersionPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage|acquisitionSdk.NativeUpdateNotification) => {
+        acquisition.queryUpdateWithCurrentPackage(lowerAppVersionPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
             assert.notEqual(null, error);
             done();
         });

--- a/sdk/test/acquisition-sdk.ts
+++ b/sdk/test/acquisition-sdk.ts
@@ -21,7 +21,7 @@ var templateCurrentPackage: acquisitionSdk.Package = {
     deploymentKey: mockApi.validDeploymentKey,
     description: "sdfsdf",
     label: "v1",
-    appVersion: latestPackage.appVersion,
+    appVersion: latestPackage.target_binary_range,
     packageHash: "hash001",
     isMandatory: false,
     packageSize: 100
@@ -30,17 +30,17 @@ var templateCurrentPackage: acquisitionSdk.Package = {
 var scriptUpdateResult: acquisitionSdk.RemotePackage = {
     deploymentKey: mockApi.validDeploymentKey,
     description: latestPackage.description,
-    downloadUrl: latestPackage.downloadURL,
+    downloadUrl: latestPackage.download_url,
     label: latestPackage.label,
-    appVersion: latestPackage.appVersion,
-    isMandatory: latestPackage.isMandatory,
-    packageHash: latestPackage.packageHash,
-    packageSize: latestPackage.packageSize
+    appVersion: latestPackage.target_binary_range,
+    isMandatory: latestPackage.is_mandatory,
+    packageHash: latestPackage.package_hash,
+    packageSize: latestPackage.package_size
 };
 
 var nativeUpdateResult: acquisitionSdk.NativeUpdateNotification = {
     updateAppVersion: true,
-    appVersion: latestPackage.appVersion
+    appVersion: latestPackage.target_binary_range
 };
 
 describe("Acquisition SDK", () => {
@@ -59,7 +59,7 @@ describe("Acquisition SDK", () => {
 
     it("Package with equal package hash gives no update", (done: MochaDone) => {
         var equalVersionPackage: acquisitionSdk.Package = clone(templateCurrentPackage);
-        equalVersionPackage.packageHash = latestPackage.packageHash;
+        equalVersionPackage.packageHash = latestPackage.package_hash;
 
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
         acquisition.queryUpdateWithCurrentPackage(equalVersionPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
@@ -153,7 +153,7 @@ describe("Acquisition SDK", () => {
     });
 
     it("If latest package is mandatory, returned package is mandatory", (done: MochaDone) => {
-        mockApi.latestPackage.isMandatory = true;
+        mockApi.latestPackage.is_mandatory = true;
 
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage) => {


### PR DESCRIPTION
* Update types of `UpdateCheckRequest`, `UpdateCheckResponse`, `DeploymentStatusReport`, `DownloadReport`.
* Update logic and test with new names.
* Small code style refactors.