### PR TITLE
Update public acquisition api paths in SDK

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "3.0.1-beta.0",
+  "version": "3.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "Management SDK for the CodePush service",
   "main": "script/index.js",
   "scripts": {

--- a/sdk/script/acquisition-sdk.ts
+++ b/sdk/script/acquisition-sdk.ts
@@ -94,7 +94,7 @@ export class AcquisitionManager {
             client_unique_id: this._clientUniqueId
         };
 
-        var requestUrl: string = this._serverUrl + "update_check?" + queryStringify(updateRequest);
+        var requestUrl: string = this._serverUrl + "v0.1/public/codepush/update_check?" + queryStringify(updateRequest);
 
         this._httpRequester.request(Http.Verb.GET, requestUrl, (error: Error, response: Http.Response) => {
             if (error) {
@@ -147,7 +147,7 @@ export class AcquisitionManager {
     }
 
     public reportStatusDeploy(deployedPackage?: Package, status?: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string, callback?: Callback<void>): void {
-        var url: string = this._serverUrl + "report_status/deploy";
+        var url: string = this._serverUrl + "v0.1/public/codepush/report_status/deploy";
         var body: DeploymentStatusReport = {
             app_version: this._appVersion,
             deployment_key: this._deploymentKey
@@ -207,7 +207,7 @@ export class AcquisitionManager {
     }
 
     public reportStatusDownload(downloadedPackage: Package, callback?: Callback<void>): void {
-        var url: string = this._serverUrl + "report_status/download";
+        var url: string = this._serverUrl + "v0.1/public/codepush/report_status/download";
         var body: DownloadReport = {
             client_unique_id: this._clientUniqueId,
             deployment_key: this._deploymentKey,

--- a/sdk/test/acquisition-rest-mock.ts
+++ b/sdk/test/acquisition-rest-mock.ts
@@ -20,9 +20,9 @@ export var latestPackage = <rest.UpdateCheckResponse>{
 };
 
 export var serverUrl = "http://myurl.com";
-var reportStatusDeployUrl = serverUrl + "/report_status/deploy";
-var reportStatusDownloadUrl = serverUrl + "/report_status/download";
-var updateCheckUrl = serverUrl + "/update_check?";
+var reportStatusDeployUrl = serverUrl + "/v0.1/public/codepush/report_status/deploy";
+var reportStatusDownloadUrl = serverUrl + "/v0.1/public/codepush/report_status/download";
+var updateCheckUrl = serverUrl + "/v0.1/public/codepush/update_check?";
 
 export class HttpRequester implements acquisitionSdk.Http.Requester {
     public request(verb: acquisitionSdk.Http.Verb, url: string, requestBodyOrCallback: string | acquisitionSdk.Callback<acquisitionSdk.Http.Response>, callback?: acquisitionSdk.Callback<acquisitionSdk.Http.Response>): void {


### PR DESCRIPTION
In order to use the new CodePush API service, we need to make sure to use the correct public API prefixes for CodePush.

The changes in this pull request update the paths in the SDK code as well as the tests and bump the version of the SDK to 3.0.0-beta.1.