### PR TITLE
Revert back to legacy api for management calls

### DIFF
--- a/sdk/script/management-sdk.ts
+++ b/sdk/script/management-sdk.ts
@@ -44,8 +44,8 @@ class AccountManager {
         OWNER: "Owner",
         COLLABORATOR: "Collaborator"
     };
-    public static SERVER_URL = "https://codepush.appcenter.ms";
-    public static MOBILE_CENTER_SERVER_URL = "https://appcenter.ms";
+    public static SERVER_URL = "https://codepush-management.azurewebsites.net";
+    public static MOBILE_CENTER_SERVER_URL = "https://mobile.azure.com";
 
     private static API_VERSION: number = 2;
 


### PR DESCRIPTION
In order to keep the management SDK working as expected, we decided to switch it back to the legacy endpoint. We will work on deprecating the old CodePush services soon and will pick up the topic when we are working on this feature.