### PR TITLE
Remove update notice banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-UPDATE: Over the next few months, we will be working on a new version of CodePush that will address some of the most common performance issues our customers are facing. This updated version will allow a better experience, our team to better support CodePush moving forward and have a faster development cycle for new features.
-We are prioritizing this work because we believe this to be the most valuable thing we can do for our CodePush customers in the long run. Starting June 11th 2019, support will slow down, bug fixes will be limited to critical bugs, and new feature development will pause until we finish this core update.
-
----
-
 [![appcenterbanner](https://user-images.githubusercontent.com/31293287/32969262-3cc5d48a-cb99-11e7-91bf-fa57c67a371c.png)](http://microsoft.github.io/code-push/)
 
 #### [Sign up With App Center](https://appcenter.ms/signup?utm_source=CodePush&utm_medium=Azure) to use CodePush


### PR DESCRIPTION
This notice is about a project to modernize the CodePush backend. This project was finished at the end of 2019 and the team has picked up additional bug fixes and is addressing Github issues again. We therefore can remove the notice again to avoid any additional confusion.