### PR TITLE
Replace Q.Promise with es5 Promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "code-push",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -20,12 +20,6 @@
       "version": "13.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.0.tgz",
       "integrity": "sha512-uM4mnmsIIPK/yeO+42F2RQhGUIs39K2RFmugcJANppXe6J1nvH87PvzPZYpza7Xhhs8Yn9yIAVdLZ84z61+0xQ==",
-      "dev": true
-    },
-    "@types/q": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
-      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
     },
     "@types/slash": {
@@ -1161,11 +1155,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
       "version": "6.9.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "license": "MIT",
   "homepage": "https://microsoft.github.io/code-push",
   "dependencies": {
-    "q": "^1.5.1",
     "recursive-fs": "^2.1.0",
     "slash": "^3.0.0",
     "superagent": "^5.2.1",
@@ -33,7 +32,6 @@
   "devDependencies": {
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.11.0",
-    "@types/q": "^1.5.2",
     "@types/slash": "^3.0.0",
     "@types/superagent": "^4.1.4",
     "@types/yazl": "^2.4.2",

--- a/src/script/management-sdk.ts
+++ b/src/script/management-sdk.ts
@@ -1,14 +1,11 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import Q = require("q");
 import slash = require("slash");
 import superagent = require("superagent");
 import * as recursiveFs from "recursive-fs";
 import * as yazl from "yazl";
 import { CodePushUnauthorizedError } from "../utils/code-push-error"
-
-import Promise = Q.Promise;
 
 import { AccessKey, AccessKeyRequest, Account, App, AppCreationRequest, CodePushError, CollaboratorMap, CollaboratorProperties, Deployment, DeploymentMetrics, Headers, Package, PackageInfo, ServerAccessKey, Session, UpdateMetrics } from "./types";
 
@@ -75,7 +72,7 @@ class AccountManager {
     }
 
     public isAuthenticated(throwIfUnauthorized?: boolean): Promise<boolean> {
-        return Promise<any>((resolve, reject, notify) => {
+        return new  Promise<any>((resolve, reject) => {
             var request: superagent.Request = superagent.get(this._serverUrl + urlEncode`/authenticated`);
             if (this._proxy) (<any>request).proxy(this._proxy);
             this.attachCredentials(request);
@@ -302,7 +299,7 @@ class AccountManager {
 
     public release(appName: string, deploymentName: string, filePath: string, targetBinaryVersion: string, updateMetadata: PackageInfo, uploadProgressCallback?: (progress: number) => void): Promise<Package> {
 
-        return Promise<Package>((resolve, reject, notify) => {
+        return new Promise<Package>((resolve, reject) => {
 
             updateMetadata.appVersion = targetBinaryVersion;
             var request: superagent.Request = superagent.post(this._serverUrl + urlEncode`/apps/${this.appNameParam(appName)}/deployments/${deploymentName}/release`);
@@ -370,7 +367,7 @@ class AccountManager {
     private packageFileFromPath(filePath: string): Promise<PackageFile> {
         var getPackageFilePromise: Promise<PackageFile>;
         if (fs.lstatSync(filePath).isDirectory()) {
-            getPackageFilePromise = Promise<PackageFile>((resolve: (file: PackageFile) => void, reject: (reason: Error) => void): void => {
+            getPackageFilePromise =  new Promise<PackageFile>((resolve: (file: PackageFile) => void, reject: (reason: Error) => void): void => {
                 var directoryPath: string = filePath;
 
                 recursiveFs.readdirr(directoryPath, (error?: any, directories?: string[], files?: string[]): void => {
@@ -408,7 +405,9 @@ class AccountManager {
                 });
             });
         } else {
-            getPackageFilePromise = Q({ isTemporary: false, path: filePath });
+          getPackageFilePromise = new Promise<PackageFile>((resolve: (file: PackageFile) => void, reject: (reason: Error) => void): void => {
+            resolve({ isTemporary: false, path: filePath });
+          });
         }
         return getPackageFilePromise;
     }
@@ -441,7 +440,7 @@ class AccountManager {
     }
 
     private makeApiRequest(method: string, endpoint: string, requestBody: string, expectResponseBody: boolean, contentType: string): Promise<JsonResponse> {
-        return Promise<JsonResponse>((resolve, reject, notify) => {
+        return new Promise<JsonResponse>((resolve, reject) => {
             var request: superagent.Request = (<any>superagent)[method](this._serverUrl + endpoint);
             if (this._proxy) (<any>request).proxy(this._proxy);
             this.attachCredentials(request);

--- a/src/test/management-sdk.ts
+++ b/src/test/management-sdk.ts
@@ -1,5 +1,4 @@
 import assert from "assert";
-import Q from "q";
 
 import AccountManager = require("../script/management-sdk");
 
@@ -42,21 +41,21 @@ describe("Management SDK", () => {
             manager.rollback.bind(manager, "appName", "deploymentName", "targetReleaseLabel")
         ];
 
-        var result = Q<void>(null);
+        var result = Promise.resolve(null);
         methodsWithErrorHandling.forEach(function (f) {
             result = result.then(() => {
                 return testErrors(f);
             });
         });
 
-        result.done(() => {
+        result.then(() => {
             done();
         });
 
         // Test that the proper error code and text is passed through on a server error
-        function testErrors(method: any): Q.Promise<void> {
-            return Q.Promise<void>((resolve: any, reject: any, notify: any) => {
-                method().done(() => {
+        function testErrors(method: any): Promise<void> {
+            return new Promise<void>((resolve: any, reject: any) => {
+                method().then(() => {
                     assert.fail("Should have thrown an error");
                     reject();
                 }, (error: any) => {
@@ -71,7 +70,7 @@ describe("Management SDK", () => {
     it("isAuthenticated handles successful auth", (done: MochaDone) => {
         mockReturn(JSON.stringify({ authenticated: true }), 200, {});
         manager.isAuthenticated()
-            .done((authenticated: boolean) => {
+            .then((authenticated: boolean) => {
                 assert(authenticated, "Should be authenticated");
                 done();
             });
@@ -80,7 +79,7 @@ describe("Management SDK", () => {
     it("isAuthenticated handles unsuccessful auth", (done: MochaDone) => {
         mockReturn("Unauthorized", 401, {});
         manager.isAuthenticated()
-            .done((authenticated: boolean) => {
+            .then((authenticated: boolean) => {
                 assert(!authenticated, "Should not be authenticated");
                 done();
             });
@@ -91,7 +90,7 @@ describe("Management SDK", () => {
 
         // use optional parameter to ask for rejection of the promise if not authenticated
         manager.isAuthenticated(true)
-            .done((authenticated: boolean) => {
+            .then((authenticated: boolean) => {
                 assert.fail("isAuthenticated should have rejected the promise");
                 done();
             }, (err) => {
@@ -103,7 +102,7 @@ describe("Management SDK", () => {
     it("isAuthenticated handles unexpected status codes", (done: MochaDone) => {
         mockReturn("Not Found", 404, {});
         manager.isAuthenticated()
-            .done((authenticated: boolean) => {
+            .then((authenticated: boolean) => {
                 assert.fail("isAuthenticated should have rejected the promise");
                 done();
             }, (err) => {
@@ -115,7 +114,7 @@ describe("Management SDK", () => {
     it("addApp handles successful response", (done: MochaDone) => {
         mockReturn(JSON.stringify({ success: true }), 201, { location: "/appName" });
         manager.addApp("appName", "iOS", "React-Native")
-            .done((obj) => {
+            .then((obj) => {
                 assert.ok(obj);
                 done();
             }, rejectHandler);
@@ -124,7 +123,7 @@ describe("Management SDK", () => {
     it("addApp handles error response", (done: MochaDone) => {
         mockReturn(JSON.stringify({ success: false }), 404, {});
         manager.addApp("appName", "iOS", "React-Native")
-            .done((obj) => {
+            .then((obj) => {
                 throw new Error("Call should not complete successfully");
             }, (error: Error) => done());
     });
@@ -133,7 +132,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ app: {} }), 200, {});
 
         manager.getApp("appName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(obj);
                 done();
             }, rejectHandler);
@@ -143,7 +142,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ apps: [] }), 200, {});
 
         manager.renameApp("appName", "newAppName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(!obj);
                 done();
             }, rejectHandler);
@@ -153,7 +152,7 @@ describe("Management SDK", () => {
         mockReturn("", 200, {});
 
         manager.removeApp("appName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(!obj);
                 done();
             }, rejectHandler);
@@ -162,7 +161,7 @@ describe("Management SDK", () => {
     it("transferApp handles successful response", (done: MochaDone) => {
         mockReturn("", 201);
         manager.transferApp("appName", "email1")
-            .done(
+            .then(
                 () => done(),
                 rejectHandler
             );
@@ -172,7 +171,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ deployment: { name: "name", key: "key" } }), 201, { location: "/deploymentName" });
 
         manager.addDeployment("appName", "deploymentName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(obj);
                 done();
             }, rejectHandler);
@@ -182,7 +181,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ deployment: {} }), 200, {});
 
         manager.getDeployment("appName", "deploymentName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(obj);
                 done();
             }, rejectHandler);
@@ -192,7 +191,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ deployments: [] }), 200, {});
 
         manager.getDeployments("appName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(obj);
                 done();
             }, rejectHandler);
@@ -202,7 +201,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ apps: [] }), 200, {});
 
         manager.renameDeployment("appName", "deploymentName", "newDeploymentName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(!obj);
                 done();
             }, rejectHandler);
@@ -212,7 +211,7 @@ describe("Management SDK", () => {
         mockReturn("", 200, {});
 
         manager.removeDeployment("appName", "deploymentName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(!obj);
                 done();
             }, rejectHandler);
@@ -222,7 +221,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ history: [] }), 200);
 
         manager.getDeploymentHistory("appName", "deploymentName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(obj);
                 assert.equal(obj.length, 0);
                 done();
@@ -233,7 +232,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ history: [{ label: "v1" }, { label: "v2" }] }), 200);
 
         manager.getDeploymentHistory("appName", "deploymentName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(obj);
                 assert.equal(obj.length, 2);
                 assert.equal(obj[0].label, "v1");
@@ -246,7 +245,7 @@ describe("Management SDK", () => {
         mockReturn("", 404);
 
         manager.getDeploymentHistory("appName", "deploymentName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 throw new Error("Call should not complete successfully");
             }, (error: Error) => done());
     });
@@ -255,7 +254,7 @@ describe("Management SDK", () => {
         mockReturn("", 204);
 
         manager.clearDeploymentHistory("appName", "deploymentName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(!obj);
                 done();
             }, rejectHandler);
@@ -265,7 +264,7 @@ describe("Management SDK", () => {
         mockReturn("", 404);
 
         manager.clearDeploymentHistory("appName", "deploymentName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 throw new Error("Call should not complete successfully");
             }, (error: Error) => done());
     });
@@ -273,7 +272,7 @@ describe("Management SDK", () => {
     it("addCollaborator handles successful response", (done: MochaDone) => {
         mockReturn("", 201, { location: "/collaborators" });
         manager.addCollaborator("appName", "email1")
-            .done(
+            .then(
                 () => done(),
                 rejectHandler
             );
@@ -282,7 +281,7 @@ describe("Management SDK", () => {
     it("addCollaborator handles error response", (done: MochaDone) => {
         mockReturn("", 404, {});
         manager.addCollaborator("appName", "email1")
-            .done(
+            .then(
                 () => { throw new Error("Call should not complete successfully") },
                 () => done()
             );
@@ -292,7 +291,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ collaborators: {} }), 200);
 
         manager.getCollaborators("appName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(obj);
                 assert.equal(Object.keys(obj).length, 0);
                 done();
@@ -308,7 +307,7 @@ describe("Management SDK", () => {
         }), 200);
 
         manager.getCollaborators("appName")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(obj);
                 assert.equal(obj["email1"].permission, "Owner");
                 assert.equal(obj["email2"].permission, "Collaborator");
@@ -320,7 +319,7 @@ describe("Management SDK", () => {
         mockReturn("", 200, {});
 
         manager.removeCollaborator("appName", "email1")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(!obj);
                 done();
             }, rejectHandler);
@@ -330,7 +329,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ package: { description: "newDescription" } }), 200);
 
         manager.patchRelease("appName", "deploymentName", "label", { description: "newDescription" })
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(!obj);
                 done();
             }, rejectHandler);
@@ -340,7 +339,7 @@ describe("Management SDK", () => {
         mockReturn("", 400);
 
         manager.patchRelease("appName", "deploymentName", "label", {})
-            .done((obj: any) => {
+            .then((obj: any) => {
                 throw new Error("Call should not complete successfully");
             }, (error: Error) => done());
     });
@@ -349,7 +348,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ package: { description: "newDescription" } }), 200);
 
         manager.promote("appName", "deploymentName", "newDeploymentName", { description: "newDescription" })
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(obj);
                 assert.equal(obj.description, "newDescription")
                 done();
@@ -360,7 +359,7 @@ describe("Management SDK", () => {
         mockReturn("", 400);
 
         manager.promote("appName", "deploymentName", "newDeploymentName", { rollout: 123 })
-            .done((obj: any) => {
+            .then((obj: any) => {
                 throw new Error("Call should not complete successfully");
             }, (error: Error) => done());
     });
@@ -369,7 +368,7 @@ describe("Management SDK", () => {
         mockReturn(JSON.stringify({ package: { label: "v1" } }), 200);
 
         manager.rollback("appName", "deploymentName", "v1")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 assert.ok(!obj);
                 done();
             }, rejectHandler);
@@ -379,7 +378,7 @@ describe("Management SDK", () => {
         mockReturn("", 400);
 
         manager.rollback("appName", "deploymentName", "v1")
-            .done((obj: any) => {
+            .then((obj: any) => {
                 throw new Error("Call should not complete successfully");
             }, (error: Error) => done());
     });


### PR DESCRIPTION
Due to the use of Q.Promise in the code-push SDK, we are missing typing. We should replace Q.Promise with es5 Promise, which allows us to save types in the module.