### PR TITLE
fix: Mandatory flag wasn't set correctly on promote

### DIFF
--- a/src/utils/adapter/adapter.ts
+++ b/src/utils/adapter/adapter.ts
@@ -277,7 +277,7 @@ class Adapter {
 
         if (legacyCodePushReleaseInfo.isDisabled) releaseModification.is_disabled = legacyCodePushReleaseInfo.isDisabled;
 
-        if (legacyCodePushReleaseInfo.isMandatory) releaseModification.is_mandatory = legacyCodePushReleaseInfo.isMandatory;
+        if (legacyCodePushReleaseInfo.isMandatory !== undefined) releaseModification.is_mandatory = legacyCodePushReleaseInfo.isMandatory === true;
 
         if (legacyCodePushReleaseInfo.description) releaseModification.description = legacyCodePushReleaseInfo.description;
 


### PR DESCRIPTION
If `isMandatory` is set to `false` during a promote and the source deployment has `isMandatory` as `true`, the resultant deployment will have `isMandatory` set to `true` because of the way the check was implemented.  
This PR fixes that behaviour and ensures the right flag is set.