### PR TITLE
[Enhancement] Use a network `Response` as `error.cause` #806

### DIFF
--- a/src/script/acquisition-sdk.ts
+++ b/src/script/acquisition-sdk.ts
@@ -109,7 +109,7 @@ export class AcquisitionManager {
                 } else {
                     errorMessage = `${response.statusCode}: ${response.body}`;
                 }
-                callback(new CodePushHttpError(errorMessage), /*remotePackage=*/ null);
+                callback(new CodePushHttpError(errorMessage, response), /*remotePackage=*/ null);
                 return;
             }
             try {
@@ -197,7 +197,7 @@ export class AcquisitionManager {
                 }
 
                 if (response.statusCode !== 200) {
-                    callback(new CodePushHttpError(response.statusCode + ": " + response.body), /*not used*/ null);
+                    callback(new CodePushHttpError(response.statusCode + ": " + response.body, response), /*not used*/ null);
                     return;
                 }
 
@@ -222,7 +222,7 @@ export class AcquisitionManager {
                 }
 
                 if (response.statusCode !== 200) {
-                    callback(new CodePushHttpError(response.statusCode + ": " + response.body), /*not used*/ null);
+                    callback(new CodePushHttpError(response.statusCode + ": " + response.body, response), /*not used*/ null);
                     return;
                 }
 

--- a/src/script/code-push-error.ts
+++ b/src/script/code-push-error.ts
@@ -1,13 +1,19 @@
+import {Http} from "./acquisition-sdk";
+
 export class CodePushError extends Error {
-    constructor(message: string) {
-        super(message);
+    constructor(message: string, options?: unknown) {
+        super(
+            message,
+            // @ts-expect-error - need to enable es2022 (see: https://github.com/microsoft/TypeScript/blob/main/src/lib/es2022.error.d.ts)
+            options
+        );
         Object.setPrototypeOf(this, CodePushError.prototype);
     }
 }
 
 export class CodePushHttpError extends CodePushError {
-    constructor(message: string) {
-        super(message);
+    constructor(message: string, response: Http.Response) {
+        super(message, {cause: response});
         Object.setPrototypeOf(this, CodePushHttpError.prototype);
     }
 }


### PR DESCRIPTION
- Fix for https://github.com/microsoft/code-push/issues/806
