### PR TITLE
fix: added ci check for declaartions and added fix for the same

### DIFF
--- a/.github/scripts/check-for-declaration-files.ts
+++ b/.github/scripts/check-for-declaration-files.ts
@@ -1,0 +1,44 @@
+import fs from "fs";
+import path from "path";
+
+type ResultType = {
+    js : Record<string , boolean>
+    ts : Record<string , boolean>
+}
+
+const result: ResultType = {js:{} , ts:{}}
+
+const readThroughDirectory = (directory: string): void => {
+  const __directoryPath = path.join(process.env.INIT_CWD ?? '', directory);
+  const files = fs.readdirSync(__directoryPath);
+  files.forEach((file) => {
+    const filePath = path.join(__directoryPath, file);
+    const stats = fs.statSync(filePath);
+    if (stats.isDirectory()) {
+      readThroughDirectory(filePath);
+    }
+
+    if(filePath.endsWith('.js')){
+        const name = filePath.split('.')
+        name.pop()
+        result.js[name.join('.')] = true
+    }
+
+    if(filePath.endsWith('.d.ts')){
+        const name = filePath.split('.')
+        name.pop()
+        name.pop()
+        result.ts[name.join('.')] = true
+    }
+
+  });
+
+  Object.keys(result.js).forEach(file => {
+    if(!result.ts[file]){
+        throw new Error(`Declaration File Missing for ${file}.js`)
+    }
+  })
+  
+};
+
+readThroughDirectory('./bin')

--- a/.github/workflows/code-push-ci.yml
+++ b/.github/workflows/code-push-ci.yml
@@ -22,3 +22,23 @@ jobs:
         run: npm run build 
       - name: Run tests 
         run: npm run test
+
+  build-check:
+    name: Should have declarartion files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup NodeJs
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Setup dependencies
+        run: npm run setup
+      - name: Generate Release
+        run: npm run build:release
+      - name: Check For Declaration
+        run: |
+          npm i -g ts-node
+          ts-node .github/scripts/check-for-declaration-files.ts
+

--- a/tsconfig-release.json
+++ b/tsconfig-release.json
@@ -2,7 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "sourceMap": false,
-        "declaration": true
+        "declaration": true,
+        "outDir": "bin"
     },
     "exclude": [
         "src/test"


### PR DESCRIPTION
## [Issue](https://github.com/microsoft/code-push/issues/811)
In the latest version for [code-push web sdk](https://www.npmjs.com/package/code-push?activeTab=code) no declarations files are committed due to which ts is failing.

## Fix
Added `outDir` addition option in `tsconfig-release.json` which fixes the issue
<img width="266" alt="image" src="https://github.com/microsoft/code-push/assets/32166676/46e9683e-01ff-4e1b-8276-c595a3facc1b">


## Prevention
Added a build check so that this should not happen in future releases

<img width="903" alt="image" src="https://github.com/microsoft/code-push/assets/32166676/2b5a2ce9-bc7f-4c69-9143-be644a06926a">

