### PR TITLE
Fix CI by setting macos 13 on github actions

### DIFF
--- a/.github/workflows/code-push-ci.yml
+++ b/.github/workflows/code-push-ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   Run-tests:
     name: Test code-push-sdk
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
Mac images was updated on agents to use arm type. Our build is now failing on installing node 14.
Set macos-13 to fix the issue.