### PR TITLE
Disable api calls

### DIFF
--- a/src/script/acquisition-sdk.ts
+++ b/src/script/acquisition-sdk.ts
@@ -66,7 +66,7 @@ export class AcquisitionManager {
     private _ignoreAppVersion: boolean;
     private _serverUrl: string;
     private _publicPrefixUrl: string = "v0.1/public/codepush/";
-    private static _apiCallsDisabled: Boolean = false;
+     private static _apiCallsDisabled: boolean = false;
     constructor(httpRequester: Http.Requester, configuration: Configuration) {
         this._httpRequester = httpRequester;
 
@@ -81,6 +81,9 @@ export class AcquisitionManager {
         this._ignoreAppVersion = configuration.ignoreAppVersion;
     }
 
+    public static get apiCallsDisabled(): boolean {
+        return this._apiCallsDisabled;
+    }
     private disableApiCalls(statusCode: number) {
         if (this._serverUrl.includes(this.BASER_URL) && !(statusCode >= 500 || statusCode == 408 || statusCode == 429)) {
             AcquisitionManager._apiCallsDisabled = true

--- a/src/script/acquisition-sdk.ts
+++ b/src/script/acquisition-sdk.ts
@@ -84,7 +84,7 @@ export class AcquisitionManager {
 
     // Used for Tests
     public static get apiCallsDisabled(): boolean {
-        return this._apiCallsDisabled;
+        return AcquisitionManager._apiCallsDisabled;
     }
 
     private handleRequestFailure(statusCode: number) {
@@ -169,7 +169,7 @@ export class AcquisitionManager {
     public reportStatusDeploy(deployedPackage?: Package, status?: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string, callback?: Callback<void>): void {
         if (AcquisitionManager._apiCallsDisabled) {
             console.log(`[CodePush] Api calls are disabled, skipping API call`);
-            callback(null, null)
+            callback(/*error*/ null, /*not used*/ null);
             return;
         }
 
@@ -236,7 +236,7 @@ export class AcquisitionManager {
     public reportStatusDownload(downloadedPackage: Package, callback?: Callback<void>): void {
         if (AcquisitionManager._apiCallsDisabled) {
             console.log(`[CodePush] Api calls are disabled, skipping API call`);
-            callback(null, null)
+            callback(/*error*/ null, /*not used*/ null);
             return;
         }
 

--- a/src/script/acquisition-sdk.ts
+++ b/src/script/acquisition-sdk.ts
@@ -58,7 +58,7 @@ export class AcquisitionStatus {
 }
 
 export class AcquisitionManager {
-    private readonly BASER_URL_PART = "appcenter.ms"
+    private readonly BASER_URL_PART = "appcenter.ms";
     private _appVersion: string;
     private _clientUniqueId: string;
     private _deploymentKey: string;
@@ -66,6 +66,7 @@ export class AcquisitionManager {
     private _ignoreAppVersion: boolean;
     private _serverUrl: string;
     private _publicPrefixUrl: string = "v0.1/public/codepush/";
+
     private static _apiCallsDisabled: boolean = false;
     constructor(httpRequester: Http.Requester, configuration: Configuration) {
         this._httpRequester = httpRequester;
@@ -80,6 +81,7 @@ export class AcquisitionManager {
         this._deploymentKey = configuration.deploymentKey;
         this._ignoreAppVersion = configuration.ignoreAppVersion;
     }
+
     // Used for Tests
     public static get apiCallsDisabled(): boolean {
         return this._apiCallsDisabled;
@@ -93,7 +95,7 @@ export class AcquisitionManager {
 
     public queryUpdateWithCurrentPackage(currentPackage: Package, callback?: Callback<RemotePackage | NativeUpdateNotification>): void {
         if (AcquisitionManager._apiCallsDisabled) {
-            console.log(`[CodePush] Api calls are disabled, skipping queryUpdateWithCurrentPackage`);
+            console.log(`[CodePush] Api calls are disabled, skipping API call`);
             callback(/*error=*/ null, /*remotePackage=*/ null);
             return;
         }
@@ -166,7 +168,8 @@ export class AcquisitionManager {
 
     public reportStatusDeploy(deployedPackage?: Package, status?: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string, callback?: Callback<void>): void {
         if (AcquisitionManager._apiCallsDisabled) {
-            console.log(`[CodePush] Api calls are disabled, skipping reportStatusDeploy`);
+            console.log(`[CodePush] Api calls are disabled, skipping API call`);
+            callback(null, null)
             return;
         }
 
@@ -232,7 +235,8 @@ export class AcquisitionManager {
 
     public reportStatusDownload(downloadedPackage: Package, callback?: Callback<void>): void {
         if (AcquisitionManager._apiCallsDisabled) {
-            console.log(`[CodePush] Api calls are disabled, skipping reportStatusDownload`);
+            console.log(`[CodePush] Api calls are disabled, skipping API call`);
+            callback(null, null)
             return;
         }
 
@@ -255,6 +259,7 @@ export class AcquisitionManager {
                     callback(new CodePushHttpError(response.statusCode + ": " + response.body), /*not used*/ null);
                     return;
                 }
+
                 callback(/*error*/ null, /*not used*/ null);
             }
         });

--- a/src/script/acquisition-sdk.ts
+++ b/src/script/acquisition-sdk.ts
@@ -118,7 +118,7 @@ export class AcquisitionManager {
                 return;
             }
 
-            if (response.statusCode !== 200) {
+            if (response.statusCode < 200 || response.statusCode >= 300) {
                 let errorMessage: any;
                 this._statusCode = response.statusCode;
                 this.handleRequestFailure();
@@ -220,7 +220,7 @@ export class AcquisitionManager {
                     return;
                 }
 
-                if (response.statusCode !== 200) {
+                if (response.statusCode < 200 || response.statusCode >= 300) {
                     this._statusCode = response.statusCode;
                     this.handleRequestFailure();
                     callback(new CodePushHttpError(response.statusCode + ": " + response.body), /*not used*/ null);
@@ -253,7 +253,7 @@ export class AcquisitionManager {
                     return;
                 }
 
-                if (response.statusCode !== 200) {
+                if (response.statusCode < 200 || response.statusCode >= 300) {
                     this._statusCode = response.statusCode;
                     this.handleRequestFailure();
                     callback(new CodePushHttpError(response.statusCode + ": " + response.body), /*not used*/ null);

--- a/src/script/acquisition-sdk.ts
+++ b/src/script/acquisition-sdk.ts
@@ -94,6 +94,7 @@ export class AcquisitionManager {
     public queryUpdateWithCurrentPackage(currentPackage: Package, callback?: Callback<RemotePackage | NativeUpdateNotification>): void {
         if (AcquisitionManager._apiCallsDisabled) {
             console.log(`[CodePush] Api calls are disabled, skipping queryUpdateWithCurrentPackage`);
+            callback(/*error=*/ null, /*remotePackage=*/ null);
             return;
         }
 
@@ -165,7 +166,7 @@ export class AcquisitionManager {
 
     public reportStatusDeploy(deployedPackage?: Package, status?: string, previousLabelOrAppVersion?: string, previousDeploymentKey?: string, callback?: Callback<void>): void {
         if (AcquisitionManager._apiCallsDisabled) {
-            console.log(`[CodePush] Api calls are disabled, skipping queryUpdateWithCurrentPackage`);
+            console.log(`[CodePush] Api calls are disabled, skipping reportStatusDeploy`);
             return;
         }
 
@@ -231,7 +232,7 @@ export class AcquisitionManager {
 
     public reportStatusDownload(downloadedPackage: Package, callback?: Callback<void>): void {
         if (AcquisitionManager._apiCallsDisabled) {
-            console.log(`[CodePush] Api calls are disabled, skipping queryUpdateWithCurrentPackage`);
+            console.log(`[CodePush] Api calls are disabled, skipping reportStatusDownload`);
             return;
         }
 

--- a/src/script/acquisition-sdk.ts
+++ b/src/script/acquisition-sdk.ts
@@ -82,10 +82,6 @@ export class AcquisitionManager {
         this._ignoreAppVersion = configuration.ignoreAppVersion;
     }
 
-    // Used for Tests
-    public static get apiCallsDisabled(): boolean {
-        return AcquisitionManager._apiCallsDisabled;
-    }
 
     private handleRequestFailure(statusCode: number) {
         if (this._serverUrl.includes(this.BASER_URL_PART) && !(statusCode >= 500 || statusCode == 408 || statusCode == 429)) {

--- a/src/script/acquisition-sdk.ts
+++ b/src/script/acquisition-sdk.ts
@@ -58,7 +58,7 @@ export class AcquisitionStatus {
 }
 
 export class AcquisitionManager {
-    readonly BASER_URL = "https://codepush.appcenter.ms"
+    private readonly BASER_URL = "https://codepush.appcenter.ms"
     private _appVersion: string;
     private _clientUniqueId: string;
     private _deploymentKey: string;

--- a/src/test/acquisition-rest-mock.ts
+++ b/src/test/acquisition-rest-mock.ts
@@ -28,13 +28,13 @@ export function updateMockUrl() {
     updateCheckUrl = serverUrl + publicPrefixUrl + "/update_check?";
 }
 
-
 export class HttpRequester implements acquisitionSdk.Http.Requester {
     private expectedStatusCode: number;
 
     constructor(expectedStatusCode?: number) {
         this.expectedStatusCode = expectedStatusCode;
     }
+
     public request(verb: acquisitionSdk.Http.Verb, url: string, requestBodyOrCallback: string | acquisitionSdk.Callback<acquisitionSdk.Http.Response>, callback?: acquisitionSdk.Callback<acquisitionSdk.Http.Response>): void {
         if (!callback && typeof requestBodyOrCallback === "function") {
             callback = <acquisitionSdk.Callback<acquisitionSdk.Http.Response>>requestBodyOrCallback;
@@ -42,11 +42,11 @@ export class HttpRequester implements acquisitionSdk.Http.Requester {
 
         if (verb === acquisitionSdk.Http.Verb.GET && url.indexOf(updateCheckUrl) === 0) {
             var params = querystring.parse(url.substring(updateCheckUrl.length));
-            Server.onUpdateCheck(params, callback,this.expectedStatusCode);
+            Server.onUpdateCheck(params, callback, this.expectedStatusCode);
         } else if (verb === acquisitionSdk.Http.Verb.POST && url === reportStatusDeployUrl) {
-            Server.onReportStatus(callback,this.expectedStatusCode);
+            Server.onReportStatus(callback, this.expectedStatusCode);
         } else if (verb === acquisitionSdk.Http.Verb.POST && url === reportStatusDownloadUrl) {
-            Server.onReportStatus(callback,this.expectedStatusCode);
+            Server.onReportStatus(callback, this.expectedStatusCode);
         } else {
             throw new Error("Unexpected call");
         }

--- a/src/test/acquisition-rest-mock.ts
+++ b/src/test/acquisition-rest-mock.ts
@@ -22,7 +22,19 @@ var reportStatusDeployUrl = serverUrl + publicPrefixUrl + "/report_status/deploy
 var reportStatusDownloadUrl = serverUrl + publicPrefixUrl + "/report_status/download";
 var updateCheckUrl = serverUrl + publicPrefixUrl + "/update_check?";
 
+export function updateMockUrl() {
+    reportStatusDeployUrl = serverUrl + publicPrefixUrl + "/report_status/deploy";
+    reportStatusDownloadUrl = serverUrl + publicPrefixUrl + "/report_status/download";
+    updateCheckUrl = serverUrl + publicPrefixUrl + "/update_check?";
+}
+
+
 export class HttpRequester implements acquisitionSdk.Http.Requester {
+    private expectedStatusCode: number;
+
+    constructor(expectedStatusCode?: number) {
+        this.expectedStatusCode = expectedStatusCode;
+    }
     public request(verb: acquisitionSdk.Http.Verb, url: string, requestBodyOrCallback: string | acquisitionSdk.Callback<acquisitionSdk.Http.Response>, callback?: acquisitionSdk.Callback<acquisitionSdk.Http.Response>): void {
         if (!callback && typeof requestBodyOrCallback === "function") {
             callback = <acquisitionSdk.Callback<acquisitionSdk.Http.Response>>requestBodyOrCallback;
@@ -30,11 +42,11 @@ export class HttpRequester implements acquisitionSdk.Http.Requester {
 
         if (verb === acquisitionSdk.Http.Verb.GET && url.indexOf(updateCheckUrl) === 0) {
             var params = querystring.parse(url.substring(updateCheckUrl.length));
-            Server.onUpdateCheck(params, callback);
+            Server.onUpdateCheck(params, callback,this.expectedStatusCode);
         } else if (verb === acquisitionSdk.Http.Verb.POST && url === reportStatusDeployUrl) {
-            Server.onReportStatus(callback);
+            Server.onReportStatus(callback,this.expectedStatusCode);
         } else if (verb === acquisitionSdk.Http.Verb.POST && url === reportStatusDownloadUrl) {
-            Server.onReportStatus(callback);
+            Server.onReportStatus(callback,this.expectedStatusCode);
         } else {
             throw new Error("Unexpected call");
         }
@@ -73,7 +85,7 @@ class Server {
         }
     }
 
-    public static onUpdateCheck(params: any, callback: acquisitionSdk.Callback<acquisitionSdk.Http.Response>): void {
+    public static onUpdateCheck(params: any, callback: acquisitionSdk.Callback<acquisitionSdk.Http.Response>, expectedStatusCode?: number): void {
         var updateRequest: types.UpdateCheckRequest = {
             deployment_key: params.deployment_key,
             app_version: params.app_version,
@@ -97,13 +109,13 @@ class Server {
             }
 
             callback(/*error=*/ null, {
-                statusCode: 200,
+                statusCode: expectedStatusCode ? expectedStatusCode : 200,
                 body: JSON.stringify({ update_info: updateInfo })
             });
         }
     }
 
-    public static onReportStatus(callback: acquisitionSdk.Callback<acquisitionSdk.Http.Response>): void {
-        callback(/*error*/ null, /*response*/ { statusCode: 200 });
+    public static onReportStatus(callback: acquisitionSdk.Callback<acquisitionSdk.Http.Response>, expectedStatusCode: number): void {
+        callback(/*error*/ null, /*response*/ { statusCode: expectedStatusCode ? expectedStatusCode : 200 });
     }
 }

--- a/src/test/acquisition-sdk.ts
+++ b/src/test/acquisition-sdk.ts
@@ -226,7 +226,22 @@ describe("Acquisition SDK", () => {
             done();
         }));
     });
+
+    it("disables api calls on unsuccessful response", (done: Mocha.Done): void => {
+        var invalidJsonResponse: acquisitionSdk.Http.Response = {
+            statusCode: 404,
+            body: "Not found"
+        };
+        configuration={...configuration, serverUrl:"https://codepush.appcenter.ms"}
+        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(invalidJsonResponse), configuration);
+        acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
+            done();
+        });
+    })
 });
+
+
 
 function clone<T>(initialObject: T): T {
     return JSON.parse(JSON.stringify(initialObject));

--- a/src/test/acquisition-sdk.ts
+++ b/src/test/acquisition-sdk.ts
@@ -229,6 +229,7 @@ describe("Acquisition SDK", () => {
             done();
         }));
     });
+
     it("disables api calls on unsuccessful response", (done: Mocha.Done): void => {
         var invalidJsonResponse: acquisitionSdk.Http.Response = {
             statusCode: 404,
@@ -249,7 +250,6 @@ describe("Acquisition SDK", () => {
             assert.strictEqual(returnPackage, null);
             acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(404), configuration);
             (acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled = false;
-
         });
 
         acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
@@ -266,6 +266,7 @@ describe("Acquisition SDK", () => {
 
         done();
     })
+
     it("doesn't disable api calls on successful response", (done: Mocha.Done): void => {
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
         mockApi.serverUrl = "https://codepush.appcenter.ms";

--- a/src/test/acquisition-sdk.ts
+++ b/src/test/acquisition-sdk.ts
@@ -229,7 +229,15 @@ describe("Acquisition SDK", () => {
 
     it("doesnt disable api calls on successful response", (done: Mocha.Done): void => {
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
-        
+
+        acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+        });
+
+        acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
+            assert.notStrictEqual(returnPackage, null)
+        });
+
         acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
             assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
         }))
@@ -251,6 +259,13 @@ describe("Acquisition SDK", () => {
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
             assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
         });
+
+        acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
+        }))
+        acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
+        }));
 
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
             assert.strictEqual(returnPackage, null);

--- a/src/test/acquisition-sdk.ts
+++ b/src/test/acquisition-sdk.ts
@@ -4,6 +4,7 @@ import * as acquisitionSdk from "../script/acquisition-sdk";
 import * as acquisitionRestMock from "./acquisition-rest-mock";
 import * as types from "../script/types";
 import { CodePushPackageError } from "../script/code-push-error"
+import { updateMockUrl } from "./acquisition-rest-mock";
 
 const mockApi = acquisitionRestMock;
 var latestPackage: types.UpdateCheckResponse = clone(mockApi.latestPackage);
@@ -44,6 +45,8 @@ var nativeUpdateResult: acquisitionSdk.NativeUpdateNotification = {
 describe("Acquisition SDK", () => {
     beforeEach(() => {
         mockApi.latestPackage = clone(latestPackage);
+        mockApi.serverUrl = "http://myurl.com";
+        updateMockUrl();
     });
 
     it("Package with lower label and different package hash gives update", (done: Mocha.Done) => {
@@ -226,50 +229,64 @@ describe("Acquisition SDK", () => {
             done();
         }));
     });
-
-    it("doesnt disable api calls on successful response", (done: Mocha.Done): void => {
-        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
-
-        acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
-        });
-
-        acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
-            assert.notStrictEqual(returnPackage, null)
-        });
-
-        acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
-        }))
-
-        acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
-        }));
-        done();
-    })
-
     it("disables api calls on unsuccessful response", (done: Mocha.Done): void => {
         var invalidJsonResponse: acquisitionSdk.Http.Response = {
             statusCode: 404,
             body: "Not found"
         };
-        configuration = { ...configuration, serverUrl: "https://codepush.appcenter.ms" }
-        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(invalidJsonResponse), configuration);
 
+        mockApi.serverUrl = "https://codepush.appcenter.ms";
+        updateMockUrl();
+        configuration = { ...configuration, serverUrl: "https://codepush.appcenter.ms" };
+
+        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(invalidJsonResponse), configuration);
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
             assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
+            (acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled = false;
+        });
+
+        acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
+            assert.strictEqual(returnPackage, null);
+            acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(404), configuration);
+            (acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled = false;
+
         });
 
         acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
             assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
-        }))
-        acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
+            acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(404), configuration);
+            (acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled = false;
         }));
 
+        acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
+            acquisition = acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(invalidJsonResponse), configuration);
+            (acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled = false;
+        }));
+
+        done();
+    })
+    it("doesn't disable api calls on successful response", (done: Mocha.Done): void => {
+        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
+        mockApi.serverUrl = "https://codepush.appcenter.ms";
+        updateMockUrl();
+
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
-            assert.strictEqual(returnPackage, null);
-        })
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+        });
+
+        acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
+            assert.notStrictEqual(returnPackage, null);
+        });
+
+        acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+        }));
+
+        acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+        }));
+
         done();
     })
 

--- a/src/test/acquisition-sdk.ts
+++ b/src/test/acquisition-sdk.ts
@@ -234,14 +234,31 @@ describe("Acquisition SDK", () => {
         };
         configuration = { ...configuration, serverUrl: "https://codepush.appcenter.ms" }
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(invalidJsonResponse), configuration);
+
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
             assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
             done();
         });
+
+        acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
+            assert.strictEqual(returnPackage, undefined);
+            done();
+        })
+    })
+
+    it("doesn't disable api calls on successful response", (done: Mocha.Done): void => {
+        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
+
+        acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+        }))
+
+        acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+            done();
+        }));
     })
 });
-
-
 
 function clone<T>(initialObject: T): T {
     return JSON.parse(JSON.stringify(initialObject));

--- a/src/test/acquisition-sdk.ts
+++ b/src/test/acquisition-sdk.ts
@@ -232,7 +232,7 @@ describe("Acquisition SDK", () => {
             statusCode: 404,
             body: "Not found"
         };
-        configuration={...configuration, serverUrl:"https://codepush.appcenter.ms"}
+        configuration = { ...configuration, serverUrl: "https://codepush.appcenter.ms" }
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(invalidJsonResponse), configuration);
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
             assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);

--- a/src/test/acquisition-sdk.ts
+++ b/src/test/acquisition-sdk.ts
@@ -227,6 +227,19 @@ describe("Acquisition SDK", () => {
         }));
     });
 
+    it("doesnt disable api calls on successful response", (done: Mocha.Done): void => {
+        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
+        
+        acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+        }))
+
+        acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
+            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+        }));
+        done();
+    })
+
     it("disables api calls on unsuccessful response", (done: Mocha.Done): void => {
         var invalidJsonResponse: acquisitionSdk.Http.Response = {
             statusCode: 404,
@@ -237,27 +250,14 @@ describe("Acquisition SDK", () => {
 
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
             assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
-            done();
         });
 
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
-            assert.strictEqual(returnPackage, undefined);
-            done();
+            assert.strictEqual(returnPackage, null);
         })
+        done();
     })
 
-    it("doesn't disable api calls on successful response", (done: Mocha.Done): void => {
-        var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(), configuration);
-
-        acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
-        }))
-
-        acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
-            done();
-        }));
-    })
 });
 
 function clone<T>(initialObject: T): T {

--- a/src/test/acquisition-sdk.ts
+++ b/src/test/acquisition-sdk.ts
@@ -241,7 +241,7 @@ describe("Acquisition SDK", () => {
 
         var acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(invalidJsonResponse), configuration);
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
+            assert.strictEqual((acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled, true);
             (acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled = false;
         });
 
@@ -253,13 +253,13 @@ describe("Acquisition SDK", () => {
         });
 
         acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
+            assert.strictEqual((acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled, true);
             acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.HttpRequester(404), configuration);
             (acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled = false;
         }));
 
         acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, true);
+            assert.strictEqual((acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled, true);
             acquisition = acquisition = new acquisitionSdk.AcquisitionManager(new mockApi.CustomResponseHttpRequester(invalidJsonResponse), configuration);
             (acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled = false;
         }));
@@ -272,7 +272,7 @@ describe("Acquisition SDK", () => {
         updateMockUrl();
 
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+            assert.strictEqual((acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled, false);
         });
 
         acquisition.queryUpdateWithCurrentPackage(templateCurrentPackage, (error: Error, returnPackage: acquisitionSdk.RemotePackage | acquisitionSdk.NativeUpdateNotification) => {
@@ -280,11 +280,11 @@ describe("Acquisition SDK", () => {
         });
 
         acquisition.reportStatusDeploy(templateCurrentPackage, acquisitionSdk.AcquisitionStatus.DeploymentSucceeded, "1.5.0", mockApi.validDeploymentKey, ((error: Error, parameter: void): void => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+            assert.strictEqual((acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled, false);
         }));
 
         acquisition.reportStatusDownload(templateCurrentPackage, ((error: Error, parameter: void): void => {
-            assert.strictEqual(acquisitionSdk.AcquisitionManager.apiCallsDisabled, false);
+            assert.strictEqual((acquisitionSdk.AcquisitionManager as any)._apiCallsDisabled, false);
         }));
 
         done();


### PR DESCRIPTION
## Description
Implemented feature for stopping api calls from being sent after unsuccessful response. This behavior is aligned with other appcenter SDKs. Disabling of api calls occurs only per session after first failed request.

## Related PRs or issues
[AB#107980](https://dev.azure.com/msmobilecenter/Mobile-Center/_workitems/edit/107980)